### PR TITLE
Auto scale user image to preserve texture memory

### DIFF
--- a/components/JROverhang.bs
+++ b/components/JROverhang.bs
@@ -105,8 +105,11 @@ function createUserPoster() as object
   end if
 
   userImage.id = "userImage"
-  userImage.width = "36"
-  userImage.height = "36"
+  userImage.width = 36
+  userImage.loadWidth = 36
+  userImage.height = 36
+  userImage.loadHeight = 36
+  userImage.loadDisplayMode = "limitSize"
   userImage.addFields({
     userId: localUser.id
   })

--- a/components/login/UserItem.xml
+++ b/components/login/UserItem.xml
@@ -2,7 +2,7 @@
 <component name="UserItem" extends="Group">
   <children>
     <LayoutGroup layoutDirection="vert" itemSpacings="[15]">
-      <Poster id="profileImage" width="300" height="300" loadDisplayMode="scaleToZoom" />
+      <Poster id="profileImage" width="300" loadWidth="300" height="300" loadHeight="300" loadDisplayMode="limitSize" />
       <LabelPrimaryMedium id="profileName" bold="true" horizAlign="center" vertAlign="center" height="64" width="300" />
     </LayoutGroup>
   </children>


### PR DESCRIPTION

## Changes
- Use `loadWidth`, `loadHeight`, and `limitSize` to automatically resize the user image as needed and preserve roku OS texture memory

## Issues
Fixes #119
