### PR TITLE
Fix transcoding errors for usernames with spaces (Jellyfin 10.11.x)

### DIFF
--- a/source/utils/session.bs
+++ b/source/utils/session.bs
@@ -198,8 +198,9 @@ namespace user
       userNode.authToken = myAuthToken
     end if
 
-    ' Create friendly name
-    regex = CreateObject("roRegex", "[^a-zA-Z0-9\ \-\_]", "")
+    ' Create friendly name (URL-safe, no spaces or special chars)
+    ' Used for serverDeviceName which appears in URLs and HTTP headers
+    regex = CreateObject("roRegex", "[^a-zA-Z0-9\-\_]", "")
     friendlyName = regex.ReplaceAll(userNode.name, "")
     userNode.friendlyName = friendlyName
 

--- a/tests/source/unit/utils/SessionUsernameSanitization.spec.bs
+++ b/tests/source/unit/utils/SessionUsernameSanitization.spec.bs
@@ -1,0 +1,292 @@
+
+namespace tests
+
+  @suite("session.bs - Username Sanitization for URL-safe DeviceId")
+  class SessionUsernameSanitizationTests extends tests.BaseTestSuite
+
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    @describe("user.Login() - friendlyName creation (URL-safe, no spaces)")
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+    @it("removes special characters AND spaces from friendlyName")
+    function _()
+      ' Arrange
+      userData = {
+        id: "test-user-123",
+        name: "John.R.Doe!",
+        authToken: "test-token"
+      }
+
+      ' Act
+      user.Login(userData, false)
+
+      ' Assert
+      localUser = m.getTestUser()
+      ' Period and exclamation removed, no spaces in original
+      m.assertEqual("JohnRDoe", localUser.friendlyName)
+      ' Original name unchanged
+      m.assertEqual("John.R.Doe!", localUser.name)
+    end function
+
+    @it("removes spaces from friendlyName for URL safety")
+    function _()
+      ' Arrange
+      userData = {
+        id: "test-user-456",
+        name: "John Doe",
+        authToken: "test-token"
+      }
+
+      ' Act
+      user.Login(userData, false)
+
+      ' Assert
+      localUser = m.getTestUser()
+      ' Spaces removed from friendlyName
+      m.assertEqual("JohnDoe", localUser.friendlyName)
+      ' Original name unchanged (used for UI display)
+      m.assertEqual("John Doe", localUser.name)
+    end function
+
+    @it("removes multiple spaces and special chars from friendlyName")
+    function _()
+      ' Arrange - Realistic LDAP username format
+      userData = {
+        id: "test-user-789",
+        name: "Jane A. Doe",
+        authToken: "test-token"
+      }
+
+      ' Act
+      user.Login(userData, false)
+
+      ' Assert
+      localUser = m.getTestUser()
+      ' Period AND spaces removed
+      m.assertEqual("JaneADoe", localUser.friendlyName)
+      ' Original preserved
+      m.assertEqual("Jane A. Doe", localUser.name)
+    end function
+
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    @describe("user.SetServerDeviceName() - Uses URL-safe friendlyName")
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+    @it("serverDeviceName has no spaces (friendlyName is URL-safe)")
+    function _()
+      ' Arrange
+      userData = {
+        id: "test-user-fix",
+        name: "John Doe",
+        authToken: "test-token"
+      }
+      user.Login(userData, false)
+
+      localDevice = m.global.device
+      originalDeviceId = localDevice.id
+
+      ' Act - SetServerDeviceName is called during Login
+      user.SetServerDeviceName()
+
+      ' Assert
+      localDevice = m.global.device
+      localUser = m.getTestUser()
+
+      ' friendlyName has no spaces (URL-safe)
+      m.assertEqual("JohnDoe", localUser.friendlyName)
+
+      ' serverDeviceName = deviceId + friendlyName (both URL-safe)
+      expectedDeviceName = originalDeviceId + "JohnDoe"
+      m.assertEqual(expectedDeviceName, localDevice.serverDeviceName)
+
+      ' Verify no spaces in serverDeviceName
+      hasSpaces = (localDevice.serverDeviceName.Instr(" ") >= 0)
+      m.assertFalse(hasSpaces, "serverDeviceName must not contain spaces for URL safety")
+    end function
+
+    @it("handles LDAP format names (John R. Doe)")
+    function _()
+      ' Arrange - Real-world bug scenario from issue #568
+      userData = {
+        id: "ldap-user",
+        name: "John R. Doe",
+        authToken: "test-token"
+      }
+      user.Login(userData, false)
+
+      localDevice = m.global.device
+      deviceId = localDevice.id
+
+      ' Act
+      user.SetServerDeviceName()
+
+      ' Assert
+      localDevice = m.global.device
+      localUser = m.getTestUser()
+
+      ' friendlyName has spaces AND period removed
+      m.assertEqual("JohnRDoe", localUser.friendlyName)
+
+      ' serverDeviceName uses the URL-safe friendlyName
+      expectedDeviceName = deviceId + "JohnRDoe"
+      m.assertEqual(expectedDeviceName, localDevice.serverDeviceName)
+
+      ' Critical: Must be URL-safe
+      hasSpaces = (localDevice.serverDeviceName.Instr(" ") >= 0)
+      m.assertFalse(hasSpaces, "Spaces cause 'Malformed input to URL function' error")
+    end function
+
+    @it("serverDeviceName is URL-safe for all problematic usernames")
+    function _()
+      ' Arrange - Test multiple problematic usernames
+      problematicNames = [
+        { name: "John Doe", expected: "JohnDoe" },
+        { name: "Jane A. Smith", expected: "JaneASmith" },
+        { name: "Bob Test User", expected: "BobTestUser" },
+        { name: "User With Many Spaces", expected: "UserWithManySpaces" }
+      ]
+
+      localDevice = m.global.device
+      deviceId = localDevice.id
+
+      for each testCase in problematicNames
+        ' Reset user
+        user.Logout()
+
+        userData = {
+          id: "test-user",
+          name: testCase.name,
+          authToken: "test-token"
+        }
+
+        ' Act
+        user.Login(userData, false)
+        user.SetServerDeviceName()
+
+        ' Assert
+        localDevice = m.global.device
+        localUser = m.getTestUser()
+        expectedDeviceName = deviceId + testCase.expected
+
+        ' friendlyName should match expected (no spaces)
+        m.assertEqual(testCase.expected, localUser.friendlyName, "friendlyName failed for: " + testCase.name)
+
+        ' serverDeviceName should be deviceId + friendlyName
+        m.assertEqual(expectedDeviceName, localDevice.serverDeviceName, "serverDeviceName failed for: " + testCase.name)
+
+        ' Verify URL-safe (no spaces)
+        hasSpaces = (localDevice.serverDeviceName.Instr(" ") >= 0)
+        m.assertFalse(hasSpaces, "serverDeviceName must be URL-safe for: " + testCase.name)
+      end for
+
+      return true
+    end function
+
+    @it("handles empty friendlyName after sanitization")
+    function _()
+      ' Arrange - Username that becomes empty after sanitization
+      userData = {
+        id: "test-empty",
+        name: "!@#$   ", ' Only special chars and spaces
+        authToken: "test-token"
+      }
+      user.Login(userData, false)
+
+      localDevice = m.global.device
+      deviceId = localDevice.id
+
+      ' Act
+      user.SetServerDeviceName()
+
+      ' Assert
+      localDevice = m.global.device
+      localUser = m.getTestUser()
+
+      ' friendlyName is empty
+      m.assertEqual("", localUser.friendlyName)
+
+      ' When friendlyName is empty, serverDeviceName = deviceId only
+      m.assertEqual(deviceId, localDevice.serverDeviceName)
+    end function
+
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    @describe("Regression tests - Edge cases")
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+    @it("preserves underscores and hyphens (URL-safe chars)")
+    function _()
+      ' Arrange
+      userData = {
+        id: "test-user",
+        name: "user_name-test",
+        authToken: "test-token"
+      }
+      user.Login(userData, false)
+
+      ' Act
+      user.SetServerDeviceName()
+
+      ' Assert
+      localDevice = m.global.device
+      localUser = m.getTestUser()
+
+      ' Underscores and hyphens preserved in friendlyName
+      m.assertEqual("user_name-test", localUser.friendlyName)
+
+      ' And therefore in serverDeviceName
+      m.assertTrue(localDevice.serverDeviceName.Instr("user_name-test") > 0)
+    end function
+
+    @it("handles very long usernames")
+    function _()
+      ' Arrange
+      longName = "This Is A Very Long Username With Many Words That Could Cause Issues"
+      userData = {
+        id: "test-long",
+        name: longName,
+        authToken: "test-token"
+      }
+      user.Login(userData, false)
+
+      ' Act
+      user.SetServerDeviceName()
+
+      ' Assert
+      localDevice = m.global.device
+      localUser = m.getTestUser()
+
+      ' friendlyName should have no spaces
+      expectedFriendlyName = "ThisIsAVeryLongUsernameWithManyWordsThatCouldCauseIssues"
+      m.assertEqual(expectedFriendlyName, localUser.friendlyName)
+
+      ' Should work even with long names
+      m.assertNotEqual("", localDevice.serverDeviceName)
+
+      ' Must be URL-safe (no spaces)
+      hasSpaces = (localDevice.serverDeviceName.Instr(" ") >= 0)
+      m.assertFalse(hasSpaces)
+    end function
+
+    @it("handles alphanumeric usernames without modification")
+    function _()
+      ' Arrange
+      userData = {
+        id: "test-alphanumeric",
+        name: "user123",
+        authToken: "test-token"
+      }
+      user.Login(userData, false)
+
+      ' Act
+      user.SetServerDeviceName()
+
+      ' Assert
+      localUser = m.getTestUser()
+
+      ' Alphanumeric names should pass through unchanged
+      m.assertEqual("user123", localUser.friendlyName)
+    end function
+
+  end class
+
+end namespace


### PR DESCRIPTION
## Problem
**NEW BUG in Jellyfin 10.11.x:** Users with spaces in their usernames (e.g., "John R. Doe", "Jane A. Smith") experience transcoding failures after upgrading their Jellyfin server to version 10.11.0+:
```
Curl error: Malformed input to a URL function
```

This commonly affects LDAP-synced usernames that use full names. The bug only appears when using Jellyfin server 10.11.x - direct play still works, but transcoding fails.

## Root Cause
The `friendlyName` field was keeping spaces while removing other special characters. This `friendlyName` is used to create `serverDeviceName`, which is sent as the `DeviceId` in HTTP Authorization headers.

With Jellyfin 10.11.x, the server now uses this DeviceId in transcoding URLs. Spaces in URL/header values cause encoding issues, resulting in transcoding failures.

## Solution
Modified the `friendlyName` regex in `user.Login()` to remove spaces along with other special characters:
- **Before:** `[^a-zA-Z0-9\ \-\_]` (kept spaces)
- **After:** `[^a-zA-Z0-9\-\_]` (removes spaces)

The `friendlyName` is now fully URL-safe for Jellyfin 10.11.x, while `name` (the original username) remains unchanged for UI display.

## Testing
Added comprehensive unit tests in `SessionUsernameSanitization.spec.bs` covering:
- Usernames with spaces ("John Doe" → friendlyName: "JohnDoe")
- LDAP format names ("Jane A. Smith" → friendlyName: "JaneASmith")
- Special characters and spaces ("John.R.Doe!" → friendlyName: "JohnRDoe")
- Edge cases (empty names, very long names, etc.)

All tests verify `serverDeviceName` is URL-safe with no spaces.

## Behavior Changes
- **`name`**: Unchanged, used for UI display (e.g., "John R. Doe")
- **`friendlyName`**: Now removes spaces for URL safety (e.g., "JohnRDoe")
- **`serverDeviceName`**: Now fully URL-safe (e.g., "device-123JohnRDoe")

## Affected Users
- Users with spaces in their Jellyfin username
- Using Jellyfin server version 10.11.0 or higher
- Attempting to transcode media (direct play works fine)

Fixes jellyfin/jellyfin#15155