### PR TITLE
Fix audio/subtitle stream selection for LoadVideoContentTask

### DIFF
--- a/components/ItemGrid/LoadVideoContentTask.bs
+++ b/components/ItemGrid/LoadVideoContentTask.bs
@@ -297,7 +297,7 @@ end sub
 '
 ' @param {object} meta - metadata object containing MediaStreams
 ' @param {integer} selectedAudioIndex - index of selected audio stream
-' @return {integer} indicating the default track's server-side index. Defaults to {SubtitleSelection.none} is one is not found
+' @return {integer} indicating the default track's server-side index. Defaults to {SubtitleSelection.none} if one is not found
 function defaultSubtitleTrackFromVid(meta as object, selectedAudioIndex as integer) as integer
   userSession = m.global.user
   if userSession.config.subtitleMode = "None"

--- a/source/utils/misc.bs
+++ b/source/utils/misc.bs
@@ -734,7 +734,9 @@ function findPreferredAudioStreamIndex(streams as dynamic, playDefault as dynami
     end if
     ' Fallback: return first default audio stream's Jellyfin index
     if defaultStreams.Count() > 0
-      return defaultStreams[0].index
+      if isValid(defaultStreams[0].index)
+        return defaultStreams[0].index
+      end if
     end if
   end if
 


### PR DESCRIPTION
## Summary
Fixes critical bugs in audio and subtitle track selection affecting initial playback and auto-queued episodes.

Fixes #161 
Fixes #162 
Fixes #163

## Key Fixes
- **Multiple default audio streams**: Now checks language preference when choosing between default streams
- **Auto-queued episodes**: Fixed to respect audio language preferences  
- **Metadata-first architecture**: Fetch complete metadata before making stream selection decisions
- **Performance**: Eliminated duplicate ItemMetaData() API calls (~200-500ms savings per video)
- **Subtitle state sync**: Fixed confusion between notset (-2) and none (-1)

## Technical Changes
- Enhanced `findPreferredAudioStreamIndex()` to check all default streams for language match
- Moved audio selection logic to after metadata fetch in `LoadItems_AddVideoContent()`
- Updated `defaultSubtitleTrackFromVid()` to accept meta object instead of fetching internally
- Removed `FindPreferredAudioStream()` wrapper function

## Testing
Tested with anime content containing multiple default audio tracks (JP/EN). Verified correct audio selection based on language preferences for both initial playback and auto-queued episodes.