### PR TITLE
Add `Play Default Audio Track` setting

### DIFF
--- a/components/ItemGrid/LoadVideoContentTask.bs
+++ b/components/ItemGrid/LoadVideoContentTask.bs
@@ -81,7 +81,10 @@ sub LoadItems_AddVideoContent(video as object, mediaSourceId as dynamic, audio_s
   ' Task field > 0 means user manually selected from MovieDetails/TVListDetails - preserve it
   if m.top.selectedAudioStreamIndex = 0
     if isValid(meta.json) and isValid(meta.json.MediaStreams)
-      audio_stream_idx = findBestAudioStreamIndex(meta.json.MediaStreams, userSettings.playbackPlayDefaultAudioTrack, userSession.config.audioLanguagePreference)
+      ' Resolve playDefaultAudioTrack setting (JellyRock override or web client)
+      playDefault = resolvePlayDefaultAudioTrack(userSettings, userSession.config)
+
+      audio_stream_idx = findBestAudioStreamIndex(meta.json.MediaStreams, playDefault, userSession.config.audioLanguagePreference)
     else
       ' MediaStreams not available - keep existing behavior of using 0
       ' This should never happen since ItemMetaData() just fetched metadata

--- a/components/data/jellyfin/JellyfinUserSettings.xml
+++ b/components/data/jellyfin/JellyfinUserSettings.xml
@@ -32,6 +32,7 @@
     <field id="playbackMpeg4" type="boolean" alwaysNotify="true" />
     <field id="playbackTryDirectH264ProfileLevel" type="boolean" alwaysNotify="true" />
     <field id="playbackTryDirectHevcProfileLevel" type="boolean" alwaysNotify="true" />
+    <field id="playbackPlayDefaultAudioTrack" type="string" alwaysNotify="true" />
 
     <!-- UI Settings -->
     <field id="uiGeneralEpisodeImages" type="string" alwaysNotify="true" />

--- a/components/movies/MovieDetails.bs
+++ b/components/movies/MovieDetails.bs
@@ -283,8 +283,11 @@ sub SetDefaultAudioTrack(itemData)
   ' Get user settings for audio selection
   localUser = m.global.user
 
+  ' Resolve playDefaultAudioTrack setting (JellyRock override or web client)
+  playDefault = resolvePlayDefaultAudioTrack(localUser.settings, localUser.config)
+
   ' Use new comprehensive audio selection logic
-  selectedIndex = findBestAudioStreamIndex(mediaStreams, localUser.settings.playbackPlayDefaultAudioTrack, localUser.config.audioLanguagePreference)
+  selectedIndex = findBestAudioStreamIndex(mediaStreams, playDefault, localUser.config.audioLanguagePreference)
 
   ' Find the audio stream with the selected index to get its displayTitle
   defaultAudioStream = invalid

--- a/components/tvshows/TVListDetails.bs
+++ b/components/tvshows/TVListDetails.bs
@@ -209,8 +209,11 @@ sub SetDefaultAudioTrack(itemData as object, item as object)
   ' Get user settings for audio selection
   localUser = m.global.user
 
+  ' Resolve playDefaultAudioTrack setting (JellyRock override or web client)
+  playDefault = resolvePlayDefaultAudioTrack(localUser.settings, localUser.config)
+
   ' Use new comprehensive audio selection logic
-  selectedIndex = findBestAudioStreamIndex(mediaStreams, localUser.settings.playbackPlayDefaultAudioTrack, localUser.config.audioLanguagePreference)
+  selectedIndex = findBestAudioStreamIndex(mediaStreams, playDefault, localUser.config.audioLanguagePreference)
 
   ' Set the selected audio stream index on the item node
   item.selectedAudioStreamIndex = selectedIndex

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -120,6 +120,27 @@
         ]
       },
       {
+        "title": "Play Default Audio Track",
+        "description": "Override web client audio preference. When enabled, use the IsDefault flag to select audio track. When disabled, prefer language match and ignore IsDefault.",
+        "settingName": "playbackPlayDefaultAudioTrack",
+        "type": "radio",
+        "default": "webclient",
+        "options": [
+          {
+            "title": "Use Web Client Setting",
+            "id": "webclient"
+          },
+          {
+            "title": "Enabled",
+            "id": "enabled"
+          },
+          {
+            "title": "Disabled",
+            "id": "disabled"
+          }
+        ]
+      },
+      {
         "title": "Preferred Surround Audio Codec",
         "description": "When transcoding multichannel audio, prefer this codec. EAC3 supports up to 7.1 channels with better compression. AC3 is more widely compatible. DTS is an alternative for systems that prefer it. This only affects 6 and 8 channel transcoding profiles.",
         "settingName": "playbackPreferredMultichannelCodec",

--- a/source/data/SessionDataTransformer.bs
+++ b/source/data/SessionDataTransformer.bs
@@ -109,7 +109,7 @@ class SessionDataTransformer
       return settingsNode
     end if
 
-    ' Playback Settings (13)
+    ' Playback Settings
     settingsNode.playbackBitrateMaxLimited = toBoolean(settingsData["playbackBitrateMaxLimited"])
     if settingsData.DoesExist("playbackBitrateLimit")
       settingsNode.playbackBitrateLimit = Val(settingsData["playbackBitrateLimit"])
@@ -121,6 +121,7 @@ class SessionDataTransformer
       settingsNode.playbackNextUpButtonSeconds = Val(settingsData["playbackNextUpButtonSeconds"])
     end if
     settingsNode.playbackPlayNextEpisode = settingsData["playbackPlayNextEpisode"] ?? ""
+    settingsNode.playbackPlayDefaultAudioTrack = settingsData["playbackPlayDefaultAudioTrack"] ?? ""
     settingsNode.playbackPreferredMultichannelCodec = settingsData["playbackPreferredMultichannelCodec"] ?? ""
     settingsNode.playbackSubsOnlyText = toBoolean(settingsData["playbackSubsOnlyText"])
     settingsNode.playbackMpeg2 = toBoolean(settingsData["playbackMpeg2"])
@@ -128,7 +129,7 @@ class SessionDataTransformer
     settingsNode.playbackTryDirectH264ProfileLevel = toBoolean(settingsData["playbackTryDirectH264ProfileLevel"])
     settingsNode.playbackTryDirectHevcProfileLevel = toBoolean(settingsData["playbackTryDirectHevcProfileLevel"])
 
-    ' UI Settings (14)
+    ' UI Settings
     settingsNode.uiGeneralEpisodeImages = settingsData["uiGeneralEpisodeImages"] ?? ""
     settingsNode.uiFontFallback = toBoolean(settingsData["uiFontFallback"])
     settingsNode.uiDesignHideClock = toBoolean(settingsData["uiDesignHideClock"])
@@ -146,13 +147,13 @@ class SessionDataTransformer
     settingsNode.uiTvShowsDisableUnwatchedCount = toBoolean(settingsData["uiTvShowsDisableUnwatchedCount"])
     settingsNode.uiTvShowsGoStraightToEpisodes = toBoolean(settingsData["uiTvShowsGoStraightToEpisodes"])
 
-    ' Item Grid Settings (4)
+    ' Item Grid Settings
     settingsNode.itemGridShowItemCount = toBoolean(settingsData["itemGridShowItemCount"])
     settingsNode.itemGridTitles = settingsData["itemGridTitles"] ?? ""
     settingsNode.itemGridReset = toBoolean(settingsData["itemGridReset"])
     settingsNode.itemGridMovieDefaultView = settingsData["itemGridMovieDefaultView"] ?? ""
 
-    ' Home sections (7)
+    ' Home sections
     settingsNode.homeSection0 = settingsData["homeSection0"] ?? ""
     settingsNode.homeSection1 = settingsData["homeSection1"] ?? ""
     settingsNode.homeSection2 = settingsData["homeSection2"] ?? ""
@@ -161,7 +162,7 @@ class SessionDataTransformer
     settingsNode.homeSection5 = settingsData["homeSection5"] ?? ""
     settingsNode.homeSection6 = settingsData["homeSection6"] ?? ""
 
-    ' Display settings (1)
+    ' Display settings
     settingsNode.displayLiveTvLanding = settingsData["displayLiveTvLanding"] ?? ""
 
     ' Transform display settings into nested structure

--- a/source/utils/quickplay.bs
+++ b/source/utils/quickplay.bs
@@ -39,10 +39,13 @@ namespace quickplay
       mediaStreams = itemNode.json.MediaSources[0].MediaStreams
     end if
 
+    ' Resolve playDefaultAudioTrack setting (JellyRock override or web client)
+    playDefault = resolvePlayDefaultAudioTrack(localUser.settings, localUser.config)
+
     ' Use new comprehensive audio selection logic
     audioStreamIndex = 0
     if isValid(mediaStreams)
-      audioStreamIndex = findBestAudioStreamIndex(mediaStreams, localUser.settings.playbackPlayDefaultAudioTrack, localUser.config.audioLanguagePreference)
+      audioStreamIndex = findBestAudioStreamIndex(mediaStreams, playDefault, localUser.config.audioLanguagePreference)
     end if
 
     ' resume playback if possible

--- a/source/utils/streamSelection.bs
+++ b/source/utils/streamSelection.bs
@@ -4,6 +4,40 @@ import "pkg:/source/utils/config.bs"
 ' Comprehensive audio and video stream selection utilities
 ' Combines user preferences with hardware capabilities for optimal playback
 
+' resolvePlayDefaultAudioTrack: Resolves the playDefaultAudioTrack setting value
+'
+' Checks JellyRock override setting first, then falls back to web client setting.
+' Ensures a valid boolean is always returned.
+'
+' @param {object} userSettings - JellyfinUserSettings node (JellyRock settings)
+' @param {object} userConfig - JellyfinUserConfiguration node (web client settings)
+' @returns {boolean} - Resolved playDefaultAudioTrack value (guaranteed boolean)
+function resolvePlayDefaultAudioTrack(userSettings as object, userConfig as object) as boolean
+  ' Default to true if we can't determine the value
+  defaultValue = true
+
+  ' Try to get web client setting
+  if isValid(userConfig) and isValid(userConfig.playDefaultAudioTrack)
+    ' Ensure it's actually a boolean before using it
+    valueType = Type(userConfig.playDefaultAudioTrack)
+    if valueType = "roBoolean" or valueType = "Boolean"
+      defaultValue = userConfig.playDefaultAudioTrack
+    end if
+  end if
+
+  ' Check for JellyRock override setting
+  if isValid(userSettings) and isValid(userSettings.playbackPlayDefaultAudioTrack) and userSettings.playbackPlayDefaultAudioTrack <> ""
+    if userSettings.playbackPlayDefaultAudioTrack = "enabled"
+      return true
+    else if userSettings.playbackPlayDefaultAudioTrack = "disabled"
+      return false
+      ' else "webclient" or other - use web client setting
+    end if
+  end if
+
+  return defaultValue
+end function
+
 ' findBestAudioStreamIndex: Primary function for selecting the best audio stream
 '
 ' Selection priority when playDefault = true (Jellyfin: "Play default audio track regardless of language"):

--- a/tests/source/unit/utils/resolvePlayDefaultAudioTrack.spec.bs
+++ b/tests/source/unit/utils/resolvePlayDefaultAudioTrack.spec.bs
@@ -1,0 +1,158 @@
+import "pkg:/source/utils/streamSelection.bs"
+
+namespace tests
+
+  @suite("streamSelection - resolvePlayDefaultAudioTrack()")
+  class ResolvePlayDefaultAudioTrackTests extends tests.BaseTestSuite
+
+    protected override function setup()
+      super.setup()
+    end function
+
+    ' Helper to create mock user settings node
+    private function createMockUserSettings(playbackPlayDefaultAudioTrack as dynamic) as object
+      mockSettings = {
+        playbackPlayDefaultAudioTrack: playbackPlayDefaultAudioTrack
+      }
+      return mockSettings
+    end function
+
+    ' Helper to create mock user config node
+    private function createMockUserConfig(playDefaultAudioTrack as dynamic) as object
+      mockConfig = {
+        playDefaultAudioTrack: playDefaultAudioTrack
+      }
+      return mockConfig
+    end function
+
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    @describe("JellyRock override setting tests")
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+    @it("returns true when JellyRock setting is 'enabled'")
+    function _()
+      settings = m.createMockUserSettings("enabled")
+      config = m.createMockUserConfig(false)
+      result = resolvePlayDefaultAudioTrack(settings, config)
+      m.assertEqual(result, true)
+    end function
+
+    @it("returns false when JellyRock setting is 'disabled'")
+    function _()
+      settings = m.createMockUserSettings("disabled")
+      config = m.createMockUserConfig(true)
+      result = resolvePlayDefaultAudioTrack(settings, config)
+      m.assertEqual(result, false)
+    end function
+
+    @it("uses web client setting when JellyRock setting is 'webclient'")
+    function _()
+      settings = m.createMockUserSettings("webclient")
+      config = m.createMockUserConfig(false)
+      result = resolvePlayDefaultAudioTrack(settings, config)
+      m.assertEqual(result, false)
+    end function
+
+    @it("uses web client setting when JellyRock setting is empty string")
+    function _()
+      settings = m.createMockUserSettings("")
+      config = m.createMockUserConfig(true)
+      result = resolvePlayDefaultAudioTrack(settings, config)
+      m.assertEqual(result, true)
+    end function
+
+    @it("uses web client setting when JellyRock setting is unexpected value")
+    function _()
+      settings = m.createMockUserSettings("invalid_value")
+      config = m.createMockUserConfig(false)
+      result = resolvePlayDefaultAudioTrack(settings, config)
+      m.assertEqual(result, false)
+    end function
+
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    @describe("Web client setting fallback tests")
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+    @it("returns web client value (true) when no JellyRock override")
+    function _()
+      settings = m.createMockUserSettings("")
+      config = m.createMockUserConfig(true)
+      result = resolvePlayDefaultAudioTrack(settings, config)
+      m.assertEqual(result, true)
+    end function
+
+    @it("returns web client value (false) when no JellyRock override")
+    function _()
+      settings = m.createMockUserSettings("")
+      config = m.createMockUserConfig(false)
+      result = resolvePlayDefaultAudioTrack(settings, config)
+      m.assertEqual(result, false)
+    end function
+
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    @describe("Invalid input handling")
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+    @it("returns true (default) when both settings and config are invalid")
+    function _()
+      result = resolvePlayDefaultAudioTrack(invalid, invalid)
+      m.assertEqual(result, true)
+    end function
+
+    @it("returns web client value when settings is invalid and config is valid")
+    function _()
+      config = m.createMockUserConfig(false)
+      result = resolvePlayDefaultAudioTrack(invalid, config)
+      m.assertEqual(result, false)
+    end function
+
+    @it("returns true (default) when settings is valid but config is invalid")
+    function _()
+      settings = m.createMockUserSettings("")
+      result = resolvePlayDefaultAudioTrack(settings, invalid)
+      m.assertEqual(result, true)
+    end function
+
+    @it("returns true when web client setting is not a boolean")
+    function _()
+      settings = m.createMockUserSettings("")
+      config = { playDefaultAudioTrack: "not a boolean" }
+      result = resolvePlayDefaultAudioTrack(settings, config)
+      m.assertEqual(result, true)
+    end function
+
+    @it("overrides invalid web client value when JellyRock setting is 'enabled'")
+    function _()
+      settings = m.createMockUserSettings("enabled")
+      config = { playDefaultAudioTrack: "not a boolean" }
+      result = resolvePlayDefaultAudioTrack(settings, config)
+      m.assertEqual(result, true)
+    end function
+
+    @it("overrides invalid web client value when JellyRock setting is 'disabled'")
+    function _()
+      settings = m.createMockUserSettings("disabled")
+      config = { playDefaultAudioTrack: "not a boolean" }
+      result = resolvePlayDefaultAudioTrack(settings, config)
+      m.assertEqual(result, false)
+    end function
+
+    @it("handles missing playbackPlayDefaultAudioTrack field gracefully")
+    function _()
+      settings = {}
+      config = m.createMockUserConfig(false)
+      result = resolvePlayDefaultAudioTrack(settings, config)
+      m.assertEqual(result, false)
+    end function
+
+    @it("handles missing playDefaultAudioTrack field gracefully")
+    function _()
+      settings = m.createMockUserSettings("enabled")
+      config = {}
+      result = resolvePlayDefaultAudioTrack(settings, config)
+      m.assertEqual(result, true)
+    end function
+
+  end class
+
+end namespace


### PR DESCRIPTION
Add JellyRock-specific setting to override web client audio track preference.

**Options:**
- Use Web Client Setting (default)
- Enabled - prioritize IsDefault flag
- Disabled - prefer language match, ignore IsDefault

Allows per-device control of audio track selection, useful for users who want different behavior on Roku vs other Jellyfin clients.

Ref #178 (part 2 of 2)