### PR TITLE
Enable MKV container support via manifest flag

### DIFF
--- a/manifest
+++ b/manifest
@@ -13,16 +13,18 @@ mm_icon_focus_sd=pkg:/images/branding/channel-poster_sd.png
 
 ### Splash Screen + Loading Screen Artwork
 
+splash_min_time=1500
+
 splash_screen_fhd=pkg:/images/branding/splash-screen_fhd.png
 splash_screen_hd=pkg:/images/branding/splash-screen_hd.png
 splash_screen_sd=pkg:/images/branding/splash-screen_sd.png
-
-splash_min_time=1500
 
 ui_resolutions=fhd
 
 confirm_partner_button=1
 
 supports_input_launch=1
+
+requires_mkv=1
 
 bs_const=debug=false


### PR DESCRIPTION
## Summary
Adds `requires_mkv=1` to the manifest to ensure MKV playback support is available across all device models and OS versions.

## Reasoning
Per [Roku manifest documentation](https://developer.roku.com/docs/developer-program/getting-started/architecture/channel-manifest.md#launch-requirement-attributes):

> Playing MKV files requires the use of a dynamically loaded library that is not part of the initially booted image. Therefore, an entry must be added to the manifest of any applications that require MKV support so that support is enabled when the app is launched.

MKV is a common container format in Jellyfin libraries. While testing showed no difference with this flag enabled (possibly because dev/sideloaded channels handle this differently), best case this ensures the MKV demuxer library is pre-loaded at launch and available on all production devices. Worst case it's redundant but harmless.

## Test Plan
- [x] Verified MKV file playback on local device
- [x] Confirm no regression in app launch time