### PR TITLE
LiveTV guide view not displaying on initial load

### DIFF
--- a/components/ItemGrid/ItemGrid.bs
+++ b/components/ItemGrid/ItemGrid.bs
@@ -205,7 +205,7 @@ sub loadInitialItems()
     ' For LiveTV, we want to "Fit" the item images, not zoom
     m.top.imageDisplayMode = "scaleToFit"
 
-    if userSettings.displayLiveTvLanding = "guide" and m.options.view <> "livetv"
+    if m.view = "tvGuide"
       showTvGuide()
     end if
   else if m.top.parentItem.collectionType = "CollectionFolder" or m.top.parentItem.type = "CollectionFolder" or m.top.parentItem.collectionType = "boxsets" or m.top.parentItem.Type = "Boxset" or m.top.parentItem.Type = "Boxsets" or m.top.parentItem.Type = "Folder" or m.top.parentItem.Type = "Channel"


### PR DESCRIPTION
Fixes #198

Changed line 208 in ItemGrid.bs to check m.view instead of legacy userSettings.displayLiveTvLanding and uninitialized m.options.view.

The view preference is correctly loaded into m.view from display settings (lines 106-119), so we should use that instead of checking legacy settings.