### PR TITLE
Separate TV channel number and name in OSD display

### DIFF
--- a/components/video/OSD.bs
+++ b/components/video/OSD.bs
@@ -304,16 +304,19 @@ sub setVideoSubTitle()
       currentProgram = ParseJson(m.top.currentProgram)
 
       if isValidAndNotEmpty(currentProgram)
-        ' set video title to current program name
+        ' Channel Number i.e. "CH 300"
+        if isValid(currentProgram.ChannelNumber) and currentProgram.ChannelNumber <> ""
+          currentChannelNumber = createSubtitleLabelNode("currentChannelNumber")
+          currentChannelNumber.text = tr("CH") + ` ${currentProgram.ChannelNumber}`
+
+          displaySubtitleNode(currentChannelNumber)
+        end if
+        ' Channel Name
         if isValid(currentProgram.Name)
-          currentChannel = createSubtitleLabelNode("currentChannel")
-          currentChannel.text = currentProgram.ChannelName
+          currentChannelName = createSubtitleLabelNode("currentChannelName")
+          currentChannelName.text = currentProgram.ChannelName
 
-          if isValid(currentProgram.ChannelNumber) and currentProgram.ChannelNumber <> ""
-            currentChannel.text = `${currentChannel.text} (${currentProgram.ChannelNumber})`
-          end if
-
-          displaySubtitleNode(currentChannel)
+          displaySubtitleNode(currentChannelName)
         end if
       end if
     end if


### PR DESCRIPTION
Improve OSD for live TV channels: shows channel number  and the channel name as a separate subtitle entry with a divider dot between them.

From `Channel Name (300)` to `CH 300 • Channel Name` 

No behavior changes beyond visual display; verified in local preview.