### PR TITLE
refactor: full-screen components to extend JRScreen

### DIFF
--- a/components/PersonDetails.bs
+++ b/components/PersonDetails.bs
@@ -13,12 +13,22 @@ sub init()
   m.extrasGrp.opacity = 1.0
   createDialogPallete()
   m.top.optionsAvailable = false
+
+  ' Set initial focus for scene navigation
+  m.top.lastFocus = m.dscr
 end sub
 
 sub OnScreenShown()
   ' Always set transparent backdrop for person screens
   ' Prevents stale movie/TV backdrops from persisting
   m.global.sceneManager.callFunc("setBackgroundImage", "")
+
+  ' Restore focus for scene navigation
+  if isValid(m.top.lastFocus)
+    m.top.lastFocus.setFocus(true)
+  else
+    m.top.setFocus(true)
+  end if
 end sub
 
 sub loadPerson()

--- a/components/PersonDetails.xml
+++ b/components/PersonDetails.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<component name="PersonDetails" extends="JRGroup">
+<component name="PersonDetails" extends="JRScreen">
   <interface>
     <field id="itemContent" type="node" onChange="loadPerson" />
     <field id="image" type="node" />

--- a/components/liveTv/schedule.bs
+++ b/components/liveTv/schedule.bs
@@ -30,6 +30,15 @@ sub init()
   m.channelIndex = {}
 end sub
 
+sub OnScreenShown()
+  ' Restore focus for scene navigation
+  if isValid(m.top.lastFocus)
+    m.top.lastFocus.setFocus(true)
+  else
+    m.top.setFocus(true)
+  end if
+end sub
+
 sub channelFilterSet()
   m.scheduleGrid.jumpToChannel = 0
   if isValid(m.top.filter) and m.LoadChannelsTask.filter <> m.top.filter

--- a/components/liveTv/schedule.xml
+++ b/components/liveTv/schedule.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<component name="Schedule" extends="JRGroup">
+<component name="Schedule" extends="JRScreen">
   <children>
     <RectangleBackgroundPrimary translation="[0,140]" width="1920" height="940" />
 

--- a/components/search/SearchResults.bs
+++ b/components/search/SearchResults.bs
@@ -17,11 +17,21 @@ sub init()
 
   ' Observe row item focus for backdrop updates
   m.searchSelect.observeField("rowItemFocused", "onSearchItemFocused")
+
+  ' Set initial focus for scene navigation
+  m.top.lastFocus = m.top.findNode("SearchBox")
 end sub
 
 sub OnScreenShown()
   ' Start with transparent backdrop - will update on item focus
   m.global.sceneManager.callFunc("setBackgroundImage", "")
+
+  ' Restore focus for scene navigation
+  if isValid(m.top.lastFocus)
+    m.top.lastFocus.setFocus(true)
+  else
+    m.top.setFocus(true)
+  end if
 end sub
 
 ' onSearchItemFocused: Update backdrop when search result is focused

--- a/components/search/SearchResults.xml
+++ b/components/search/SearchResults.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<component name="searchResults" extends="JRGroup">
+<component name="searchResults" extends="JRScreen">
   <children>
     <LayoutGroup layoutDirection="horiz" id="SearchAlphabox" translation="[70, 120]">
       <SearchBox id="SearchBox" visible="true" focusable="true" />

--- a/components/tvshows/TVSeasonRow.bs
+++ b/components/tvshows/TVSeasonRow.bs
@@ -6,7 +6,6 @@ sub init()
   updateSize()
 
   m.top.visible = true
-  m.top.setfocus(true)
 end sub
 
 sub updateSize()

--- a/components/tvshows/TVShowDetails.bs
+++ b/components/tvshows/TVShowDetails.bs
@@ -17,6 +17,9 @@ sub init()
   m.overview = m.top.findNode("overview")
 
   m.overview.ellipsisText = tr("... (Press * to read more)")
+
+  ' Set initial focus for scene navigation
+  m.top.lastFocus = m.shuffle
 end sub
 
 sub OnScreenShown()
@@ -29,6 +32,13 @@ sub OnScreenShown()
     end if
   else
     m.log.info("cannot set backdropUrl, m.top.itemContent is invalid")
+  end if
+
+  ' Restore focus for scene navigation
+  if isValid(m.top.lastFocus)
+    m.top.lastFocus.setFocus(true)
+  else
+    m.top.setFocus(true)
   end if
 end sub
 
@@ -81,8 +91,6 @@ sub itemContentChanged()
   end if
 
   setFieldText("overview", itemData.overview)
-
-  m.shuffle.visible = true
 
   if type(itemData.RunTimeTicks) = "LongInteger"
     setFieldText("runtime", stri(getRuntime()) + " mins")

--- a/components/tvshows/TVShowDetails.xml
+++ b/components/tvshows/TVShowDetails.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<component name="TVShowDetails" extends="JRGroup">
+<component name="TVShowDetails" extends="JRScreen">
   <children>
     <LayoutGroup id="toplevel" layoutDirection="vert" itemSpacings="[-10]">
       <LayoutGroup id="main_group" layoutDirection="horiz" itemSpacings="[15]">
@@ -17,7 +17,7 @@
           <LabelPrimaryMedium id="tagline" />
           <LabelSecondaryMedium id="overview" wrap="true" width="1400" maxLines="4" />
           <LabelSecondaryMedium id="history" />
-          <TextButton id="shuffle" text="Shuffle" translation="[90, 640]" visible="false" />
+          <TextButton id="shuffle" text="Shuffle" translation="[90, 640]" />
         </LayoutGroup>
       </LayoutGroup>
     </LayoutGroup>


### PR DESCRIPTION
## Summary
Refactors 4 full-screen components to properly extend `JRScreen` instead of `JRGroup`, enabling proper lifecycle management and consistent focus handling across the app.

## Components Refactored
- ✅ **TVShowDetails**
- ✅ **PersonDetails**  
- ✅ **SearchResults**
- ✅ **Schedule**

## Changes Made

### XML Updates
Changed inheritance from `extends="JRGroup"` to `extends="JRScreen"` for all 4 components.

### Focus Management Pattern
Implemented standardized focus management:
- **init()**: Sets `m.top.lastFocus` to the desired initial focus element
- **OnScreenShown()**: Restores focus using `m.top.lastFocus` + handles backdrop logic

### Bug Fixes
- Removed inappropriate `setFocus(true)` call from TVSeasonRow child component that was interfering with parent screen focus
- Removed unnecessary shuffle button visibility toggle in TVShowDetails (now visible by default)

## Architectural Benefits

1. **Lifecycle Hooks Now Work**: `OnScreenShown()` and `OnScreenHidden()` now execute properly via SceneManager
2. **Consistent Pattern**: All full-screen components follow the same navigation/focus pattern
3. **No More Dead Code**: Previous `OnScreenShown()` implementations were never called - now they execute
4. **Explicit Focus Control**: Screen-level focus management via `lastFocus` instead of ad-hoc child component calls

## Testing Performed
- ✅ Initial focus correct on all 4 screens
- ✅ Focus restoration works when navigating back
- ✅ Keyboard navigation unchanged
- ✅ Backdrop behavior correct

Closes #252