### PR TITLE
fix: device profile level calculation

### DIFF
--- a/source/utils/deviceCapabilities.bs
+++ b/source/utils/deviceCapabilities.bs
@@ -850,7 +850,7 @@ function getCodecProfiles() as object
       end for
     end for
 
-    hevcLevelString = (hevcLevelSupported * 30).toStr()
+    hevcLevelString = convertHevcLevelToString(hevcLevelSupported)
 
     hevcProfileArray = {
       "Type": "Video",
@@ -1080,6 +1080,13 @@ function removeDecimals(value as string) as string
   r = CreateObject("roRegex", "\.", "")
   value = r.ReplaceAll(value, "")
   return value
+end function
+
+' Convert HEVC level from float format (e.g., 5.0, 5.1, 4.1) to Jellyfin string format
+' HEVC levels are multiplied by 30 to convert to the integer representation
+' Examples: 5.0 → "150", 5.1 → "153", 4.1 → "123"
+function convertHevcLevelToString(level as float) as string
+  return (level * 30).toStr()
 end function
 
 ' does this roku device support playing 4k video?

--- a/tests/source/unit/utils/DeviceCapabilities.spec.bs
+++ b/tests/source/unit/utils/DeviceCapabilities.spec.bs
@@ -317,6 +317,30 @@ namespace tests
       m.assertEqual(removeDecimals("42"), "42") ' No decimals
     end function
 
+    @it("convertHevcLevelToString() converts HEVC levels correctly")
+    @params(5.0, "150")
+    @params(5.1, "153")
+    @params(4.1, "123")
+    @params(4.0, "120")
+    @params(3.0, "90")
+    @params(3.1, "93")
+    @params(6.0, "180")
+    @params(6.1, "183")
+    @params(6.2, "186")
+    function _(level, expectedString)
+      result = convertHevcLevelToString(level)
+      m.assertEqual(result, expectedString, "HEVC level " + level.toStr() + " should convert to " + expectedString)
+    end function
+
+    @it("convertHevcLevelToString() handles edge cases")
+    @params(0.0, "0")
+    @params(1.0, "30")
+    @params(2.0, "60")
+    function _(level, expectedString)
+      result = convertHevcLevelToString(level)
+      m.assertEqual(result, expectedString, "Edge case level " + level.toStr() + " should convert to " + expectedString)
+    end function
+
     @it("updateProfileArray() creates nested structure for codec")
     function _()
       profileArray = {}


### PR DESCRIPTION

## Changes
- fixes bug when max supported HEVC lvl is 5.0
- remove unsupported VP9 levels

