### PR TITLE
feat: improve OSD metadata display

### DIFF
--- a/components/video/OSD.bs
+++ b/components/video/OSD.bs
@@ -403,7 +403,6 @@ sub setVideoSubTitle()
   ' Official Rating
   if isValid(m.top.officialRating) and m.top.officialRating <> ""
     officialRatingNode = createSubtitleLabelNode("officialRating")
-    officialRatingNode.id = "officialRating"
     officialRatingNode.text = m.top.officialRating
     displaySubtitleNode(officialRatingNode)
   end if


### PR DESCRIPTION
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
- Movies now display production year instead of full premiere date
- Add official rating (R, PG-13, etc.) display for all media types
- Remove unused videoOfficialRating node reference from init


Before:
<img width="1920" height="1080" alt="before" src="https://github.com/user-attachments/assets/cf75dc82-72dc-4299-bf9f-6aa1a495ecf1" />

After:
<img width="1920" height="1080" alt="after" src="https://github.com/user-attachments/assets/13a79254-7c8c-48e5-8283-467dc4379e02" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/f3d0b690-4ad6-454b-b744-369b5baaa76c" />


