### PR TITLE
Fix: Backdrop not updating when watched item removed from home row

### DIFF
--- a/components/home/HomeItem.bs
+++ b/components/home/HomeItem.bs
@@ -86,7 +86,7 @@ sub itemContentChanged()
     m.itemIcon.uri = itemData.iconUrl
   end if
 
-  if itemData.isWatched
+  if isValid(itemData.isWatched) and itemData.isWatched
     m.itemPoster.isWatched = true
   else
     if LCase(itemData.type) = "series"

--- a/components/home/HomeRows.bs
+++ b/components/home/HomeRows.bs
@@ -697,10 +697,37 @@ sub updateOnNowItems()
   setRowItemSize()
 end sub
 
+' Gets an item from content at specified row and item indices
+' Performs all necessary bounds checking and validation
+' @param {array} indices - [rowIndex, itemIndex]
+' @return {dynamic} - ContentNode if valid, invalid otherwise
+function getItemAtIndices(indices as object) as dynamic
+  ' Validate indices and content exist
+  if not isValid(indices) or not isValid(m.top.content)
+    return invalid
+  end if
+
+  ' Validate row index is within bounds
+  if indices[0] < 0 or indices[0] >= m.top.content.getChildCount()
+    return invalid
+  end if
+
+  row = m.top.content.getChild(indices[0])
+  if not isValid(row)
+    return invalid
+  end if
+
+  ' Validate item index is within bounds
+  if indices[1] < 0 or indices[1] >= row.getChildCount()
+    return invalid
+  end if
+
+  return row.getChild(indices[1])
+end function
+
 sub itemSelected()
   m.selectedRowItem = m.top.rowItemSelected
-
-  m.top.selectedItem = m.top.content.getChild(m.top.rowItemSelected[0]).getChild(m.top.rowItemSelected[1])
+  m.top.selectedItem = getItemAtIndices(m.top.rowItemSelected)
 
   'Prevent the selected item event from double firing
   m.top.selectedItem = invalid
@@ -715,30 +742,11 @@ end sub
 ' Handles all validation and edge cases
 ' Used by: onItemFocused observer and row update functions after replaceChild
 sub updateBackdropForFocusedItem()
-  ' Check if valid focus position
-  if not isValid(m.top.rowItemFocused) or m.top.rowItemFocused[0] = -1 or m.top.rowItemFocused[1] = -1
-    return
-  end if
-
-  ' Ensure content exists
-  if not isValid(m.top.content) or m.top.content.getChildCount() = 0
-    return
-  end if
-
-  ' Get the focused row
-  focusedRow = m.top.content.getChild(m.top.rowItemFocused[0])
-  if not isValid(focusedRow) or focusedRow.getChildCount() = 0
-    return
-  end if
-
-  ' Get the focused item within that row
-  focusedItem = focusedRow.getChild(m.top.rowItemFocused[1])
-  if not isValid(focusedItem)
-    return
-  end if
+  ' Get the focused item with bounds checking
+  focusedItem = getItemAtIndices(m.top.rowItemFocused)
 
   ' Set background to item backdrop if available
-  if isValid(focusedItem.backdropUrl)
+  if isValid(focusedItem) and isValid(focusedItem.backdropUrl)
     m.global.sceneManager.callFunc("setBackgroundImage", focusedItem.backdropUrl)
   end if
 end sub
@@ -747,7 +755,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
   if press
     if key = "play"
       print "play was pressed from homerow"
-      itemToPlay = m.top.content.getChild(m.top.rowItemFocused[0]).getChild(m.top.rowItemFocused[1])
+      itemToPlay = getItemAtIndices(m.top.rowItemFocused)
       if isValid(itemToPlay)
         m.top.quickPlayNode = itemToPlay
       end if

--- a/tests/source/unit/components/HomeRows.spec.bs
+++ b/tests/source/unit/components/HomeRows.spec.bs
@@ -1,0 +1,362 @@
+namespace tests
+
+  @suite("HomeRows - updateBackdropForFocusedItem()")
+  class HomeRowsUpdateBackdropTests extends tests.BaseTestSuite
+
+    protected override sub setup()
+      super.setup()
+
+      ' Create a test instance of HomeRows component for isolated testing
+      m.homeRows = CreateObject("roSGNode", "HomeRows")
+
+      ' Create a mock sceneManager
+      if not m.global.doesExist("sceneManager")
+        m.global.addField("sceneManager", "node", false)
+        m.global.sceneManager = CreateObject("roSGNode", "ContentNode")
+      end if
+    end sub
+
+    protected override sub teardown()
+      super.teardown()
+      m.homeRows = invalid
+    end sub
+
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    @describe("Invalid rowItemFocused scenarios")
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+    @it("handles invalid rowItemFocused gracefully")
+    function _()
+      m.homeRows.rowItemFocused = invalid
+
+      ' Should not crash
+      m.homeRows.callFunc("updateBackdropForFocusedItem")
+
+      ' If we got here without crashing, the test passed
+      m.assertTrue(true)
+    end function
+
+    @it("handles rowItemFocused with -1 row index")
+    function _()
+      m.homeRows.rowItemFocused = [-1, 0]
+
+      ' Should not crash
+      m.homeRows.callFunc("updateBackdropForFocusedItem")
+
+      ' If we got here without crashing, the test passed
+      m.assertTrue(true)
+    end function
+
+    @it("handles rowItemFocused with -1 item index")
+    function _()
+      m.homeRows.rowItemFocused = [0, -1]
+
+      ' Should not crash
+      m.homeRows.callFunc("updateBackdropForFocusedItem")
+
+      ' If we got here without crashing, the test passed
+      m.assertTrue(true)
+    end function
+
+    @it("handles rowItemFocused with both indices -1")
+    function _()
+      m.homeRows.rowItemFocused = [-1, -1]
+
+      ' Should not crash
+      m.homeRows.callFunc("updateBackdropForFocusedItem")
+
+      ' If we got here without crashing, the test passed
+      m.assertTrue(true)
+    end function
+
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    @describe("Empty content scenarios")
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+    @it("handles invalid content gracefully")
+    function _()
+      m.homeRows.content = invalid
+      m.homeRows.rowItemFocused = [0, 0]
+
+      m.homeRows.callFunc("updateBackdropForFocusedItem")
+
+      ' If we got here without crashing, the test passed
+      m.assertTrue(true)
+    end function
+
+    @it("handles empty content (no rows)")
+    function _()
+      ' Content exists but has no children
+      m.homeRows.content = CreateObject("roSGNode", "ContentNode")
+      m.homeRows.rowItemFocused = [0, 0]
+
+      m.homeRows.callFunc("updateBackdropForFocusedItem")
+
+      ' If we got here without crashing, the test passed
+      m.assertTrue(true)
+    end function
+
+    @it("handles row with no items")
+    function _()
+      ' Create a row with no items
+      m.homeRows.content = CreateObject("roSGNode", "ContentNode")
+      m.homeRows.content.CreateChild("HomeRow")
+      m.homeRows.rowItemFocused = [0, 0]
+
+      m.homeRows.callFunc("updateBackdropForFocusedItem")
+
+      ' If we got here without crashing, the test passed
+      m.assertTrue(true)
+    end function
+
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    @describe("Out of bounds indices")
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+    @it("handles row index out of bounds (exceeds row count)")
+    function _()
+      ' Create content with 2 rows
+      m.homeRows.content = CreateObject("roSGNode", "ContentNode")
+      row1 = m.homeRows.content.CreateChild("HomeRow")
+      row1Item = row1.CreateChild("ContentNode")
+      row1Item.addField("backdropUrl", "string", false)
+      row1Item.backdropUrl = "http://test.com/backdrop1.jpg"
+
+      row2 = m.homeRows.content.CreateChild("HomeRow")
+      row2Item = row2.CreateChild("ContentNode")
+      row2Item.addField("backdropUrl", "string", false)
+      row2Item.backdropUrl = "http://test.com/backdrop2.jpg"
+
+      ' Try to access row index 2 (out of bounds - only 0 and 1 exist)
+      m.homeRows.rowItemFocused = [2, 0]
+
+      m.homeRows.callFunc("updateBackdropForFocusedItem")
+
+      ' If we got here without crashing, the test passed
+      m.assertTrue(true)
+    end function
+
+    @it("handles item index out of bounds (exceeds item count)")
+    function _()
+      ' Create content with 1 row containing 2 items
+      m.homeRows.content = CreateObject("roSGNode", "ContentNode")
+      row = m.homeRows.content.CreateChild("HomeRow")
+
+      item1 = row.CreateChild("ContentNode")
+      item1.addField("backdropUrl", "string", false)
+      item1.backdropUrl = "http://test.com/backdrop1.jpg"
+
+      item2 = row.CreateChild("ContentNode")
+      item2.addField("backdropUrl", "string", false)
+      item2.backdropUrl = "http://test.com/backdrop2.jpg"
+
+      ' Try to access item index 2 (out of bounds - only 0 and 1 exist)
+      m.homeRows.rowItemFocused = [0, 2]
+
+      m.homeRows.callFunc("updateBackdropForFocusedItem")
+
+      ' If we got here without crashing, the test passed
+      m.assertTrue(true)
+    end function
+
+    @it("handles row index at exact boundary (equals row count)")
+    function _()
+      ' Create content with 2 rows (indices 0 and 1)
+      m.homeRows.content = CreateObject("roSGNode", "ContentNode")
+      row1 = m.homeRows.content.CreateChild("HomeRow")
+      row1.CreateChild("ContentNode")
+
+      row2 = m.homeRows.content.CreateChild("HomeRow")
+      row2.CreateChild("ContentNode")
+
+      ' Try to access row index 2 (equals getChildCount())
+      m.homeRows.rowItemFocused = [2, 0]
+
+      m.homeRows.callFunc("updateBackdropForFocusedItem")
+
+      ' If we got here without crashing, the test passed
+      m.assertTrue(true)
+    end function
+
+    @it("handles item index at exact boundary (equals item count)")
+    function _()
+      ' Create content with 1 row containing 2 items (indices 0 and 1)
+      m.homeRows.content = CreateObject("roSGNode", "ContentNode")
+      row = m.homeRows.content.CreateChild("HomeRow")
+      row.CreateChild("ContentNode")
+      row.CreateChild("ContentNode")
+
+      ' Try to access item index 2 (equals getChildCount())
+      m.homeRows.rowItemFocused = [0, 2]
+
+      m.homeRows.callFunc("updateBackdropForFocusedItem")
+
+      ' If we got here without crashing, the test passed
+      m.assertTrue(true)
+    end function
+
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    @describe("Valid backdrop updates")
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+    @it("updates backdrop when all conditions are valid")
+    function _()
+      ' Create valid content structure
+      m.homeRows.content = CreateObject("roSGNode", "ContentNode")
+      row = m.homeRows.content.CreateChild("HomeRow")
+
+      item = row.CreateChild("ContentNode")
+      expectedBackdropUrl = "http://test.com/backdrop.jpg"
+      item.addField("backdropUrl", "string", false)
+      item.backdropUrl = expectedBackdropUrl
+
+      m.homeRows.rowItemFocused = [0, 0]
+
+      m.homeRows.callFunc("updateBackdropForFocusedItem")
+
+      ' Function should complete without crashing - backdrop should be set
+      m.assertTrue(true)
+    end function
+
+    @it("does not update when item has no backdropUrl field")
+    function _()
+      ' Create item without backdropUrl
+      m.homeRows.content = CreateObject("roSGNode", "ContentNode")
+      row = m.homeRows.content.CreateChild("HomeRow")
+      row.CreateChild("ContentNode")
+
+      m.homeRows.rowItemFocused = [0, 0]
+
+      m.homeRows.callFunc("updateBackdropForFocusedItem")
+
+      ' If we got here without crashing, the test passed
+      m.assertTrue(true)
+    end function
+
+    @it("does not update when item has invalid backdropUrl")
+    function _()
+      ' Create item with invalid backdropUrl
+      m.homeRows.content = CreateObject("roSGNode", "ContentNode")
+      row = m.homeRows.content.CreateChild("HomeRow")
+      item = row.CreateChild("ContentNode")
+      item.addField("backdropUrl", "string", false)
+      item.backdropUrl = invalid
+
+      m.homeRows.rowItemFocused = [0, 0]
+
+      m.homeRows.callFunc("updateBackdropForFocusedItem")
+
+      ' If we got here without crashing, the test passed
+      m.assertTrue(true)
+    end function
+
+    @it("does not update when item has empty backdropUrl")
+    function _()
+      ' Create item with empty string backdropUrl
+      m.homeRows.content = CreateObject("roSGNode", "ContentNode")
+      row = m.homeRows.content.CreateChild("HomeRow")
+      item = row.CreateChild("ContentNode")
+      item.addField("backdropUrl", "string", false)
+      item.backdropUrl = ""
+
+      m.homeRows.rowItemFocused = [0, 0]
+
+      m.homeRows.callFunc("updateBackdropForFocusedItem")
+
+      ' Should not crash (empty string is not valid)
+      m.assertTrue(true)
+    end function
+
+    @it("updates backdrop for different row and item positions")
+    @params(0, 0)
+    @params(1, 0)
+    @params(0, 1)
+    @params(1, 2)
+    function _(rowIndex, itemIndex)
+      ' Create content with 2 rows, each with 3 items
+      m.homeRows.content = CreateObject("roSGNode", "ContentNode")
+
+      for r = 0 to 1
+        row = m.homeRows.content.CreateChild("HomeRow")
+        for i = 0 to 2
+          item = row.CreateChild("ContentNode")
+          item.addField("backdropUrl", "string", false)
+          item.backdropUrl = `http://test.com/backdrop${r}${i}.jpg`
+        end for
+      end for
+
+      m.homeRows.rowItemFocused = [rowIndex, itemIndex]
+
+      m.homeRows.callFunc("updateBackdropForFocusedItem")
+
+      ' Function should complete without crashing - backdrop should be set
+      m.assertTrue(true)
+    end function
+
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    @describe("Integration with row updates")
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+    @it("updates backdrop correctly after replaceChild on focused row")
+    function _()
+      ' Create initial content
+      m.homeRows.content = CreateObject("roSGNode", "ContentNode")
+      oldRow = m.homeRows.content.CreateChild("HomeRow")
+      oldItem = oldRow.CreateChild("ContentNode")
+      oldItem.addField("backdropUrl", "string", false)
+      oldItem.backdropUrl = "http://test.com/old.jpg"
+
+      ' Focus on the item
+      m.homeRows.rowItemFocused = [0, 0]
+
+      ' Replace the row with new content
+      newRow = CreateObject("roSGNode", "HomeRow")
+      newRow.title = "New Row"
+      newItem = newRow.CreateChild("ContentNode")
+      newItem.addField("backdropUrl", "string", false)
+      newItem.backdropUrl = "http://test.com/new.jpg"
+
+      m.homeRows.content.replaceChild(newRow, 0)
+
+      ' Call updateBackdropForFocusedItem (simulating what happens in row update functions)
+      m.homeRows.callFunc("updateBackdropForFocusedItem")
+
+      ' Should update to the new item's backdrop without crashing
+      m.assertTrue(true)
+    end function
+
+    @it("handles replaceChild where new row has fewer items than focus position")
+    function _()
+      ' Create initial content with 3 items
+      m.homeRows.content = CreateObject("roSGNode", "ContentNode")
+      oldRow = m.homeRows.content.CreateChild("HomeRow")
+      for i = 0 to 2
+        item = oldRow.CreateChild("ContentNode")
+        item.addField("backdropUrl", "string", false)
+        item.backdropUrl = `http://test.com/item${i}.jpg`
+      end for
+
+      ' Focus on third item (index 2)
+      m.homeRows.rowItemFocused = [0, 2]
+
+      ' Replace with new row that only has 2 items
+      newRow = CreateObject("roSGNode", "HomeRow")
+      newRow.title = "Shorter Row"
+      for i = 0 to 1
+        item = newRow.CreateChild("ContentNode")
+        item.addField("backdropUrl", "string", false)
+        item.backdropUrl = `http://test.com/new${i}.jpg`
+      end for
+
+      m.homeRows.content.replaceChild(newRow, 0)
+
+      ' Call updateBackdropForFocusedItem
+      m.homeRows.callFunc("updateBackdropForFocusedItem")
+
+      ' Should not crash (index out of bounds is handled gracefully)
+      m.assertTrue(true)
+    end function
+
+  end class
+
+end namespace


### PR DESCRIPTION
## Problem
When a video finishes playing and the user returns to the home screen, watched items are removed from rows (e.g., Continue Watching). This caused the backdrop to show a stale image because:
- Focus is restored to the same index position (e.g., [0,0])
- Content at that index has changed (old index 1 is now at index 0)
- The `rowItemFocused` observer doesn't fire when only the data changes
- Backdrop shows the old item's image instead of the new item

## Solution
- Created `updateBackdropForFocusedItem()` helper with robust validation
- Called after `replaceChild()` in all row update functions (Continue Watching, Next Up, Favorites, Latest, On Now)
- Refactored `onItemFocused()` to use the same helper for DRY compliance
- Added defensive checks to prevent crashes during content rebuilds

## Test Plan
1. Start playing a video from Continue Watching at index 0
2. Watch until completion (or mark as watched)
3. Verify backdrop updates to show the NEW item at index 0
4. Test with different rows (Next Up, Favorites, etc.)
5. Test navigating to different rows while data is loading