### PR TITLE
fix: show trickplay thumbnails on low RAM devices

### DIFF
--- a/components/data/jellyfin/DeviceInfo.xml
+++ b/components/data/jellyfin/DeviceInfo.xml
@@ -48,5 +48,6 @@
     <!-- Performance -->
     <field id="memoryLevel" type="string" value="normal" />
     <field id="memoryTotal" type="integer" value="0" />
+    <field id="isLowMemoryDevice" type="boolean" value="false" />
   </interface>
 </component>

--- a/components/video/TrickplayCarousel.bs
+++ b/components/video/TrickplayCarousel.bs
@@ -7,6 +7,11 @@ import "pkg:/source/utils/trickplay.bs"
 sub init()
   m.log = new log.Logger("TrickplayCarousel")
 
+  ' Cache low memory device flag for texture size optimization
+  ' Low memory devices (512MB RAM) have limited texture memory (~50MB)
+  ' and cannot load full-size trickplay tiles into GPU memory
+  m.isLowMemoryDevice = m.global.device.isLowMemoryDevice
+
   ' Cache poster references in array for easy shifting [minus2, minus1, center, plus1, plus2]
   m.posterArray = [
     m.top.findNode("posterMinus2"),
@@ -100,6 +105,17 @@ sub onConfigChanged()
 
   ' Calculate thumbs per tile for velocity calculations
   m.thumbsPerTile = m.config.tileWidth * m.config.tileHeight
+
+  ' Configure preloader poster for low memory devices
+  ' Must be done after config is loaded so we know tile dimensions
+  if m.isLowMemoryDevice
+    fullTileWidth = m.config.tileWidth * m.config.width
+    fullTileHeight = m.config.tileHeight * m.config.height
+    m.preloaderPoster.loadWidth = fullTileWidth / 2
+    m.preloaderPoster.loadHeight = fullTileHeight / 2
+    m.preloaderPoster.loadDisplayMode = "limitSize"
+    m.log.info("Low memory device detected - using reduced texture size", "loadWidth", fullTileWidth / 2, "loadHeight", fullTileHeight / 2)
+  end if
 
   ' Start early tile caching immediately when config is available
   ' This ensures tiles are downloading before user starts scrubbing
@@ -641,11 +657,19 @@ sub updateSinglePoster(posterIndex as integer, thumbnailIndex as integer)
   scaleX = displayWidth / m.config.width
   scaleY = displayHeight / m.config.height
 
-  ' Calculate full tile dimensions when scaled
+  ' Calculate full tile dimensions (source image size before display scaling)
   fullTileWidth = m.config.tileWidth * m.config.width
   fullTileHeight = m.config.tileHeight * m.config.height
 
-  ' Set poster to scaled full tile size
+  ' Low memory devices: load texture at half size to fit in limited texture memory (~50MB)
+  ' Roku scales the smaller texture to fill poster.width/height, reducing quality but enabling display
+  if m.isLowMemoryDevice
+    poster.loadWidth = fullTileWidth / 2
+    poster.loadHeight = fullTileHeight / 2
+    poster.loadDisplayMode = "limitSize"
+  end if
+
+  ' Set poster to scaled full tile size for display
   poster.width = fullTileWidth * scaleX
   poster.height = fullTileHeight * scaleY
 

--- a/source/utils/globals.bs
+++ b/source/utils/globals.bs
@@ -1,3 +1,48 @@
+' Low memory device model prefixes (512MB RAM, ~50MB texture memory)
+' These devices cannot load large textures (e.g., default trickplay 10x10 320 tiles) into memory
+' See: https://github.com/cewert/jellyrock/issues/299
+const LOW_MEMORY_DEVICE_PREFIXES = [
+  ' Current Models
+  "3840", ' Roku Streaming Stick (Lakeport) - 512MB - 720p
+  "K8PX", ' Projector (Avery) - 512MB - 720p
+  "8000", ' Roku TV (Midland/El Paso) - 512MB - 720p
+  "H000", ' 2K Roku TV (Miami) - 512MB - 720p
+  "T100", ' Roku TV (Alpine) - 512MB - 720p
+  ' Updatable Models
+  "3960", ' Roku Express (Rockett) - 512MB - 720p
+  "3931", ' Roku Express+ (Nemo) - 512MB - 720p
+  "3600", ' Roku Streaming Stick (Briscoe) - 512MB - 720p
+  "3700", ' Roku Express (Littlefield) - 512MB - 720p
+  "3710", ' Roku Express+ (Littlefield) - 512MB - 720p
+  "3800", ' Roku Streaming Stick (Amarillo) - 512MB - 720p
+  "4200", ' Roku 3 (Austin) - 512MB - 720p
+  "4210", ' Roku 2 (Mustang) - 512MB - 720p
+  "4230", ' Roku 3 (Mustang) - 512MB - 720p
+  "5000", ' Roku TV (Liberty) - 512MB - 720p
+  "D000", ' Roku TV (Roma) - 512MB - 720p
+  "K000", ' Roku TV (Roxton) - 512MB - 720p
+  ' Legacy Models
+  "2700", ' Roku LT (Tyler) - 512MB - supports OS 11
+  "2710", ' Roku 1, Roku SE (Tyler) - 512MB - supports OS 11
+  "2720", ' Roku 2 (Tyler) - 512MB - supports OS 11
+  "3500" ' Roku Streaming Stick (Sugarland) - 512MB - supports OS 11
+]
+
+' Check if device model matches a low memory device (512MB RAM)
+' @param {String} deviceModel - The device model string from roDeviceInfo.GetModel()
+' @return {Boolean} - true if device is a low memory device
+function checkIsLowMemoryDevice(deviceModel as string) as boolean
+  if deviceModel = "" then return false
+
+  for each prefix in LOW_MEMORY_DEVICE_PREFIXES
+    if deviceModel.left(len(prefix)) = prefix
+      return true
+    end if
+  end for
+
+  return false
+end function
+
 ' Set all global variables that don't require an roSGNode
 sub setGlobals()
   ' Initialize session content nodes
@@ -151,6 +196,7 @@ sub SaveDeviceToGlobal()
   deviceNode.videoWidth = StrToI(videoWidth)
   deviceNode.videoRefresh = StrToI(refreshRate)
   deviceNode.videoBitDepth = bitDepth
+  deviceNode.isLowMemoryDevice = checkIsLowMemoryDevice(deviceInfo.GetModel())
 
   m.global.addFields({ device: deviceNode })
 end sub

--- a/tests/source/unit/utils/globals-lowMemory.spec.bs
+++ b/tests/source/unit/utils/globals-lowMemory.spec.bs
@@ -1,0 +1,277 @@
+
+namespace tests
+
+  @suite("globals.bs - checkIsLowMemoryDevice()")
+  class LowMemoryDeviceTests extends tests.BaseTestSuite
+
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    @describe("checkIsLowMemoryDevice(deviceModel)")
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+    @it("returns false for empty string")
+    function _()
+      result = checkIsLowMemoryDevice("")
+      m.assertEqual(result, false)
+    end function
+
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    @describe("Current 512MB Models")
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+    @it("detects Roku Streaming Stick (Lakeport) 3840 variants as low memory")
+    @params("3840X")
+    @params("3840R")
+    @params("3840RW")
+    @params("3840EU")
+    @params("3840BR")
+    @params("3840S2")
+    function _(model)
+      result = checkIsLowMemoryDevice(model)
+      m.assertEqual(result, true, `Model ${model} should be detected as low memory`)
+    end function
+
+    @it("detects Projector (Avery) K8PXX as low memory")
+    @params("K8PXX")
+    @params("K8PX1")
+    function _(model)
+      result = checkIsLowMemoryDevice(model)
+      m.assertEqual(result, true, `Model ${model} should be detected as low memory`)
+    end function
+
+    @it("detects Roku TV (Midland/El Paso) 8000X as low memory")
+    @params("8000X")
+    @params("8000R")
+    function _(model)
+      result = checkIsLowMemoryDevice(model)
+      m.assertEqual(result, true, `Model ${model} should be detected as low memory`)
+    end function
+
+    @it("detects 2K Roku TV (Miami) H000X as low memory")
+    @params("H000X")
+    @params("H0001")
+    function _(model)
+      result = checkIsLowMemoryDevice(model)
+      m.assertEqual(result, true, `Model ${model} should be detected as low memory`)
+    end function
+
+    @it("detects Roku TV (Alpine) T100X as low memory")
+    @params("T100X")
+    @params("T1001")
+    function _(model)
+      result = checkIsLowMemoryDevice(model)
+      m.assertEqual(result, true, `Model ${model} should be detected as low memory`)
+    end function
+
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    @describe("Updatable 512MB Models")
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+    @it("detects Roku Express (Rockett) 3960X as low memory")
+    @params("3960X")
+    function _(model)
+      result = checkIsLowMemoryDevice(model)
+      m.assertEqual(result, true, `Model ${model} should be detected as low memory`)
+    end function
+
+    @it("detects Roku Express+ (Nemo) 3931X as low memory")
+    @params("3931X")
+    function _(model)
+      result = checkIsLowMemoryDevice(model)
+      m.assertEqual(result, true, `Model ${model} should be detected as low memory`)
+    end function
+
+    @it("detects Roku Streaming Stick (Briscoe) 3600 variants as low memory")
+    @params("3600X")
+    @params("3600R")
+    @params("3600RW")
+    @params("3600EU")
+    function _(model)
+      result = checkIsLowMemoryDevice(model)
+      m.assertEqual(result, true, `Model ${model} should be detected as low memory`)
+    end function
+
+    @it("detects Roku Express (Littlefield) 3700 variants as low memory")
+    @params("3700X")
+    @params("3700R")
+    @params("3700RW")
+    @params("3700EU")
+    function _(model)
+      result = checkIsLowMemoryDevice(model)
+      m.assertEqual(result, true, `Model ${model} should be detected as low memory`)
+    end function
+
+    @it("detects Roku Streaming Stick (Amarillo) 3800 variants as low memory")
+    @params("3800X")
+    @params("3800R")
+    @params("3800RW")
+    @params("3800EU")
+    function _(model)
+      result = checkIsLowMemoryDevice(model)
+      m.assertEqual(result, true, `Model ${model} should be detected as low memory`)
+    end function
+
+    @it("detects Roku 3 (Austin) 4200 variants as low memory")
+    @params("4200X")
+    @params("4200R")
+    @params("4200RW")
+    @params("4200EU")
+    function _(model)
+      result = checkIsLowMemoryDevice(model)
+      m.assertEqual(result, true, `Model ${model} should be detected as low memory`)
+    end function
+
+    @it("detects Roku 2 (Mustang) 4210 variants as low memory")
+    @params("4210X")
+    @params("4210R")
+    @params("4210RW")
+    function _(model)
+      result = checkIsLowMemoryDevice(model)
+      m.assertEqual(result, true, `Model ${model} should be detected as low memory`)
+    end function
+
+    @it("detects Roku 3 (Mustang) 4230 variants as low memory")
+    @params("4230X")
+    @params("4230R")
+    @params("4230RW")
+    function _(model)
+      result = checkIsLowMemoryDevice(model)
+      m.assertEqual(result, true, `Model ${model} should be detected as low memory`)
+    end function
+
+    @it("detects Roku TV (Liberty) 5000 variants as low memory")
+    @params("5000X")
+    @params("5000R")
+    @params("5000RW")
+    function _(model)
+      result = checkIsLowMemoryDevice(model)
+      m.assertEqual(result, true, `Model ${model} should be detected as low memory`)
+    end function
+
+    @it("detects Roku TV (Roma) D000 variants as low memory")
+    @params("D000X")
+    @params("D000R")
+    @params("D000RW")
+    function _(model)
+      result = checkIsLowMemoryDevice(model)
+      m.assertEqual(result, true, `Model ${model} should be detected as low memory`)
+    end function
+
+    @it("detects Roku TV (Roxton) K000 variants as low memory")
+    @params("K000X")
+    @params("K000R")
+    @params("K000RW")
+    function _(model)
+      result = checkIsLowMemoryDevice(model)
+      m.assertEqual(result, true, `Model ${model} should be detected as low memory`)
+    end function
+
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    @describe("Legacy 512MB Models")
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+    @it("detects Roku LT (Tyler) 2700X as low memory")
+    @params("2700X")
+    function _(model)
+      result = checkIsLowMemoryDevice(model)
+      m.assertEqual(result, true, `Model ${model} should be detected as low memory`)
+    end function
+
+    @it("detects Roku 1/Roku SE (Tyler) 2710X as low memory")
+    @params("2710X")
+    function _(model)
+      result = checkIsLowMemoryDevice(model)
+      m.assertEqual(result, true, `Model ${model} should be detected as low memory`)
+    end function
+
+    @it("detects Roku 2 (Tyler) 2720X as low memory")
+    @params("2720X")
+    function _(model)
+      result = checkIsLowMemoryDevice(model)
+      m.assertEqual(result, true, `Model ${model} should be detected as low memory`)
+    end function
+
+    @it("detects Roku Streaming Stick (Sugarland) 3500X as low memory")
+    @params("3500X")
+    function _(model)
+      result = checkIsLowMemoryDevice(model)
+      m.assertEqual(result, true, `Model ${model} should be detected as low memory`)
+    end function
+
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    @describe("Non-Low-Memory Models (1GB+ RAM)")
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+    @it("returns false for Roku Ultra (1GB+ RAM)")
+    @params("4660X")
+    @params("4670X")
+    @params("4800X")
+    @params("4802X")
+    function _(model)
+      result = checkIsLowMemoryDevice(model)
+      m.assertEqual(result, false, `Model ${model} should NOT be detected as low memory`)
+    end function
+
+    @it("returns false for Roku Streaming Stick 4K (Madison) 3820 variants (1GB+ RAM)")
+    @params("3820X")
+    @params("3820R")
+    @params("3820R2")
+    @params("3820RW")
+    @params("3820RW2")
+    @params("3820EU")
+    function _(model)
+      result = checkIsLowMemoryDevice(model)
+      m.assertEqual(result, false, `Model ${model} should NOT be detected as low memory`)
+    end function
+
+    @it("returns false for Roku Streaming Stick 4K (Bayside) 3830 variants (1GB+ RAM)")
+    @params("3830X")
+    @params("3830R")
+    @params("3830RW")
+    @params("3830EU")
+    @params("3830BR")
+    @params("3830CA")
+    function _(model)
+      result = checkIsLowMemoryDevice(model)
+      m.assertEqual(result, false, `Model ${model} should NOT be detected as low memory`)
+    end function
+
+    @it("returns false for Roku Express 4K (Gilbert) 3900 variants (1GB+ RAM)")
+    @params("3900X")
+    @params("3900RW")
+    @params("3900EU")
+    function _(model)
+      result = checkIsLowMemoryDevice(model)
+      m.assertEqual(result, false, `Model ${model} should NOT be detected as low memory`)
+    end function
+
+    @it("returns false for Roku Express 4K+ 3940/3941 variants (1GB+ RAM)")
+    @params("3940X")
+    @params("3940RW")
+    @params("3940EU")
+    @params("3941X")
+    function _(model)
+      result = checkIsLowMemoryDevice(model)
+      m.assertEqual(result, false, `Model ${model} should NOT be detected as low memory`)
+    end function
+
+    @it("returns false for Roku Streaming Stick 4K (Amarillo_4K) 3810 variants (1GB+ RAM)")
+    @params("3810X")
+    @params("3810R")
+    @params("3810RW")
+    function _(model)
+      result = checkIsLowMemoryDevice(model)
+      m.assertEqual(result, false, `Model ${model} should NOT be detected as low memory`)
+    end function
+
+    @it("returns false for unknown models")
+    @params("9999X")
+    @params("ABCDE")
+    @params("1234Z")
+    function _(model)
+      result = checkIsLowMemoryDevice(model)
+      m.assertEqual(result, false, `Unknown model ${model} should NOT be detected as low memory`)
+    end function
+
+  end class
+
+end namespace


### PR DESCRIPTION
Detects 512MB RAM Roku devices and reduces texture size by 50% to fix blank trickplay thumbnails. Large tiles exceeded GPU texture memory limits and failed to load on these devices.

This reduces trickplay image quality by half but the alternative is having to change the default server trickplay settings to make ALL tiles smaller for ALL clients (i.e. 5x5 like the official client). This way, the majority of devices retrieve and use the full resolution trickplay images and the server admin gets an easy life.

## Changes
- Add LOW_MEMORY_DEVICE_PREFIXES constant with 22 device model prefixes
- Add checkIsLowMemoryDevice() function for device detection
- Store isLowMemoryDevice flag in global device state
- Apply loadWidth/loadHeight scaling in TrickplayCarousel for affected devices
- Add comprehensive unit tests for all device model variants

Low memory devices (Express, basic Streaming Stick, entry-level TVs) can now display trickplay thumbnails.

## Issues
Fixes #299
