### PR TITLE
feat: add exit confirmation dialog when pressing back on home screen

### DIFF
--- a/components/data/SceneManager.bs
+++ b/components/data/SceneManager.bs
@@ -70,6 +70,13 @@ end sub
 
 ' Remove the current group and load the last group from the stack
 sub popScene()
+  ' If this is the last scene on the stack, show exit confirmation instead of immediately exiting
+  if m.groups.count() <= 1
+    optionDialog(tr("Exit JellyRock"), [tr("Are you sure you want to exit JellyRock?")], [tr("Cancel"), tr("Exit")])
+    m.top.pendingExitConfirmation = true
+    return
+  end if
+
   group = m.groups.pop()
   if isValid(group)
     if group.isSubType("JRGroup")

--- a/components/data/SceneManager.xml
+++ b/components/data/SceneManager.xml
@@ -21,5 +21,6 @@
     <field id="currentUser" type="string" onChange="updateUser" />
     <field id="returnData" type="assocarray" />
     <field id="dataReturned" type="boolean" />
+    <field id="pendingExitConfirmation" type="boolean" value="false" />
   </interface>
 </component>

--- a/source/Main.bs
+++ b/source/Main.bs
@@ -947,8 +947,15 @@ sub Main (args as dynamic) as void
       stopLoadingSpinner()
       if isValid(popupNode) and isValid(popupNode.returnData)
         print "popupNode.returnData = ", popupNode.returnData
-        ' Handle delete confirmation dialog
-        if isValid(m.pendingDeleteItemId)
+        ' Handle exit confirmation dialog
+        if m.global.sceneManager.pendingExitConfirmation = true
+          m.global.sceneManager.pendingExitConfirmation = false
+          if popupNode.returnData.indexSelected = 1 and popupNode.returnData.buttonSelected = tr("Exit")
+            ' User confirmed exit
+            m.scene.exit = true
+          end if
+          ' Handle delete confirmation dialog
+        else if isValid(m.pendingDeleteItemId)
           if popupNode.returnData.indexSelected = 1 and popupNode.returnData.buttonSelected = tr("Delete")
             ' User confirmed deletion
             api.items.DeleteByID(m.pendingDeleteItemId)


### PR DESCRIPTION
## Changes
- add exit confirmation dialog when pressing back on home screen

## Issues
Fixes #79

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/32570555-38ba-49b2-820e-bf1d5f46abfc" />

