### PR TITLE
fix: on-device decode setting ignored when no receiver connected

### DIFF
--- a/source/utils/deviceCapabilities.bs
+++ b/source/utils/deviceCapabilities.bs
@@ -122,7 +122,7 @@ function getSupportedPassthruCodecs(di as object, channelCount as integer) as ob
   supportedCodecs = []
 
   for each codec in surroundOutputCodecs
-    if getActualCodecSupport(codec, channelCount, di)
+    if di.CanDecodeAudio({ Codec: codec, ChCnt: channelCount, PassThru: 1 }).Result
       supportedCodecs.push(codec)
     end if
   end for

--- a/tests/source/unit/utils/DeviceCapabilities.spec.bs
+++ b/tests/source/unit/utils/DeviceCapabilities.spec.bs
@@ -305,6 +305,24 @@ namespace tests
       m.assertArrayCount(result, 0, "Should return empty for 8ch when only 6ch supported")
     end function
 
+    @it("returns empty when device can native decode but has no passthrough")
+    function _()
+      ' Regression: Roku Ultra can natively decode ac3/eac3 6ch (outputs stereo PCM)
+      ' but has no receiver/soundbar for passthrough. getSupportedPassthruCodecs must
+      ' only detect actual passthrough, not native decode capability.
+      mockDi = {
+        CanDecodeAudio: function(params as object) as object
+          if params.DoesExist("PassThru") and params.PassThru = 1
+            return { Result: false } ' No passthrough (no receiver/soundbar)
+          end if
+          return { Result: true } ' Native decode supported
+        end function
+      }
+
+      result = getSupportedPassthruCodecs(mockDi, 6)
+      m.assertArrayCount(result, 0, "Should return empty when only native decode is available (no passthrough)")
+    end function
+
     '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
     @describe("Helper Functions")
     '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++


### PR DESCRIPTION
## Summary
- `getSupportedPassthruCodecs()` was calling `getActualCodecSupport()` which returns true for both passthrough AND native decode capability
- On devices like Roku Ultra that natively decode AC3/EAC3 6ch (outputting stereo PCM), this falsely flagged passthrough as available even with no receiver/soundbar connected
- This caused `hasSurroundPassthru` to be true, forcing stereo-output codecs like AAC to 2ch max in the codec profile sent to the server
- Now checks `di.CanDecodeAudio({ PassThru: 1 })` directly so only real receiver/soundbar passthrough is detected

## Test plan
- [x] Roku with no receiver/soundbar: AAC codec profile should report `AudioChannels: 6`
- [x] Roku with receiver/soundbar supporting passthrough: AAC should report `AudioChannels: 2` (triggers server transcode to surround)
- [x] Transcoding profiles `MaxAudioChannels` should reflect actual passthrough availability
- [x] Unit tests pass