### PR TITLE
fix: auto-retry with direct play on DoVi buffer overflow

### DIFF
--- a/components/ItemGrid/LoadVideoContentTask.bs
+++ b/components/ItemGrid/LoadVideoContentTask.bs
@@ -46,18 +46,19 @@ sub loadItems()
   mediaSourceId = invalid
   audio_stream_idx = m.top.selectedAudioStreamIndex
   forceTranscoding = false
+  bypassDoviPreservation = m.top.bypassDoviPreservation
 
-  m.top.content = [LoadItems_VideoPlayer(id, mediaSourceId, audio_stream_idx, forceTranscoding)]
+  m.top.content = [LoadItems_VideoPlayer(id, mediaSourceId, audio_stream_idx, forceTranscoding, bypassDoviPreservation)]
 end sub
 
-function LoadItems_VideoPlayer(id as string, mediaSourceId as dynamic, audio_stream_idx = 1 as integer, forceTranscoding = false as boolean) as dynamic
+function LoadItems_VideoPlayer(id as string, mediaSourceId as dynamic, audio_stream_idx = 1 as integer, forceTranscoding = false as boolean, bypassDoviPreservation = false as boolean) as dynamic
 
   video = {}
   video.id = id
   video.content = createObject("RoSGNode", "ContentNode")
   video.content.addField("trickplayMetadata", "assocarray", false)
 
-  LoadItems_AddVideoContent(video, mediaSourceId, audio_stream_idx, forceTranscoding)
+  LoadItems_AddVideoContent(video, mediaSourceId, audio_stream_idx, forceTranscoding, bypassDoviPreservation)
 
   if not isValid(video.content)
     return invalid
@@ -66,7 +67,7 @@ function LoadItems_VideoPlayer(id as string, mediaSourceId as dynamic, audio_str
   return video
 end function
 
-sub LoadItems_AddVideoContent(video as object, mediaSourceId as dynamic, audio_stream_idx = 1 as integer, forceTranscoding = false as boolean)
+sub LoadItems_AddVideoContent(video as object, mediaSourceId as dynamic, audio_stream_idx = 1 as integer, forceTranscoding = false as boolean, bypassDoviPreservation = false as boolean)
 
   meta = ItemMetaData(video.id)
   if not isValid(meta)
@@ -218,7 +219,7 @@ sub LoadItems_AddVideoContent(video as object, mediaSourceId as dynamic, audio_s
   if meta.live then mediaSourceId = ""
 
   ' Call ItemPostPlaybackInfo ONCE with final subtitle_idx
-  m.playbackInfo = ItemPostPlaybackInfo(video.id, mediaSourceId, audio_stream_idx, subtitle_idx, playbackPosition, meta)
+  m.playbackInfo = ItemPostPlaybackInfo(video.id, mediaSourceId, audio_stream_idx, subtitle_idx, playbackPosition, meta, bypassDoviPreservation)
   if not isValid(m.playbackInfo)
     video.errorMsg = "Error loading playback info"
     video.content = invalid
@@ -310,6 +311,16 @@ sub LoadItems_AddVideoContent(video as object, mediaSourceId as dynamic, audio_s
     video.transcodeReasons = getTranscodeReasons(m.playbackInfo.MediaSources[0].TranscodingUrl)
     video.content.url = buildURL(m.playbackInfo.MediaSources[0].TranscodingUrl)
     video.isTranscoded = true
+
+    ' If DoVi preservation caused this transcode, flag that direct play is a viable buffer-overflow fallback.
+    ' VideoRangeTypeNotSupported is the reason Jellyfin returns when our DoVi container profile blocks the MKV.
+    ' On a buffer:loop: error the player will retry with bypassDoviPreservation=true, letting the server
+    ' re-evaluate without the DoVi constraint and (usually) grant direct play instead.
+    if userSettings.playbackPreserveDovi and not bypassDoviPreservation
+      if arrayHasValue(video.transcodeReasons, "VideoRangeTypeNotSupported")
+        video.doviDirectPlayFallbackAvailable = true
+      end if
+    end if
   end if
 
   setCertificateAuthority(video.content)

--- a/components/ItemGrid/LoadVideoContentTask.xml
+++ b/components/ItemGrid/LoadVideoContentTask.xml
@@ -21,5 +21,8 @@
     <!-- Total records available from server-->
     <field id="totalRecordCount" type="int" value="-1" />
     <field id="content" type="array" />
+    <!-- When true, skips the DoVi container profile injection in ItemPostPlaybackInfo,
+         allowing the server to re-evaluate direct play without DoVi preservation constraints. -->
+    <field id="bypassDoviPreservation" type="boolean" value="false" />
   </interface>
 </component>

--- a/components/manager/ViewCreator.bs
+++ b/components/manager/ViewCreator.bs
@@ -230,6 +230,8 @@ end sub
 ' Playback state change event handlers
 sub onStateChange()
   if LCase(m.view.state) = "finished"
+    ' Don't pop the scene mid-retry; the DoVi fallback calls stop which can fire "finished".
+    if isValid(m.view.isRetrying) and m.view.isRetrying then return
     sceneManager = m.global.sceneManager
     queueManager = m.global.queueManager
 

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -512,6 +512,8 @@ sub onVideoContentLoaded()
   m.LoadMetaDataTask.unobserveField("content")
   m.LoadMetaDataTask.control = "STOP"
 
+  m.top.isRetrying = false
+
   videoContent = m.LoadMetaDataTask.content
   m.LoadMetaDataTask.content = []
 
@@ -537,6 +539,11 @@ sub onVideoContentLoaded()
   m.chapters = videoContent[0].chapters
   m.top.showID = videoContent[0].showID
   m.top.cachedPlaybackInfo = videoContent[0].playbackInfo
+  m.top.doviDirectPlayFallbackAvailable = isValid(videoContent[0].doviDirectPlayFallbackAvailable) and videoContent[0].doviDirectPlayFallbackAvailable
+
+  ' Reset bypass flag so subsequent reloads (audio/subtitle changes) re-evaluate DoVi naturally.
+  ' It will be set back to true by the error handler if another buffer overflow occurs.
+  m.LoadMetaDataTask.bypassDoviPreservation = false
 
   if isValidAndNotEmpty(videoContent[0].json)
     m.osd.json = formatJson(videoContent[0].json)
@@ -892,7 +899,25 @@ sub onState()
 
     print m.top.errorInfo
 
-    if not m.playReported and m.top.transcodeAvailable
+    ' Detect a Roku video buffer overflow (buffer:loop: source) caused by DoVi transcoding.
+    ' When DoVi preservation forced a transcode and the HLS segments overflow the device buffer,
+    ' retry with direct play by bypassing the DoVi container profile injection.
+    isBufferLoopError = isValid(m.top.errorInfo) and isValid(m.top.errorInfo.source) and m.top.errorInfo.source = "buffer:loop:"
+
+    if isBufferLoopError and m.top.doviDirectPlayFallbackAvailable
+      m.log.warn("Buffer overflow in DoVi transcode; falling back to direct play", m.currentItem.id)
+      m.top.doviDirectPlayFallbackAvailable = false ' prevent retry loop if direct play also fails
+      m.global.queueManager.callFunc("setTopStartingPoint", int(m.top.position) * 10000000&)
+      ' Prevents ViewCreator popping the scene when stop causes Roku to fire "finished".
+      m.top.isRetrying = true
+      m.top.control = "stop"
+      m.LoadMetaDataTask.bypassDoviPreservation = true
+      m.LoadMetaDataTask.selectedSubtitleIndex = m.top.SelectedSubtitle
+      m.LoadMetaDataTask.selectedAudioStreamIndex = m.top.audioIndex
+      m.LoadMetaDataTask.itemId = m.currentItem.id
+      m.LoadMetaDataTask.observeField("content", "onVideoContentLoaded")
+      m.LoadMetaDataTask.control = "RUN"
+    else if not m.playReported and m.top.transcodeAvailable
       m.log.info("retrying with transcoding", m.currentItem.id, m.top.SelectedSubtitle, m.top.audioIndex)
       m.top.retryWithTranscoding = true ' If playback was not reported, retry with transcoding
     else

--- a/components/video/VideoPlayerView.xml
+++ b/components/video/VideoPlayerView.xml
@@ -20,6 +20,12 @@
     <field id="retryWithTranscoding" type="boolean" value="false" />
     <field id="isTranscoded" type="boolean" />
     <field id="transcodeReasons" type="array" />
+    <!-- Set when DoVi preservation forced a transcode (VideoRangeTypeNotSupported).
+         On a buffer:loop: error the player retries with bypassDoviPreservation=true
+         to allow the server to grant direct play instead. -->
+    <field id="doviDirectPlayFallbackAvailable" type="boolean" value="false" />
+    <!-- Prevents ViewCreator from popping the scene during a DoVi fallback retry. -->
+    <field id="isRetrying" type="boolean" value="false" />
 
     <field id="videoId" type="string" />
     <field id="mediaSourceId" type="string" />

--- a/source/api/Items.bs
+++ b/source/api/Items.bs
@@ -4,7 +4,7 @@ import "pkg:/source/enums/SubtitleSelection.bs"
 import "pkg:/source/utils/deviceCapabilities.bs"
 import "pkg:/source/utils/misc.bs"
 
-function ItemPostPlaybackInfo(id as string, mediaSourceId = "" as string, audioTrackIndex = -1 as integer, subtitleTrackIndex = SubtitleSelection.none as integer, startTimeTicks = 0& as longinteger, videoMetadata = invalid as dynamic)
+function ItemPostPlaybackInfo(id as string, mediaSourceId = "" as string, audioTrackIndex = -1 as integer, subtitleTrackIndex = SubtitleSelection.none as integer, startTimeTicks = 0& as longinteger, videoMetadata = invalid as dynamic, bypassDoviPreservation = false as boolean)
   globalUser = m.global.user
   postData = {
     "UserId": globalUser.id,
@@ -80,8 +80,9 @@ function ItemPostPlaybackInfo(id as string, mediaSourceId = "" as string, audioT
   end if
 
   ' DOVI not supported using MKV container, so force remux for DOVI content
-  ' Only run DOVI logic if the user setting exists and is enabled
-  if isValid(mediaStreams) and isValid(globalUser.settings.playbackPreserveDovi) and globalUser.settings.playbackPreserveDovi
+  ' Only run DOVI logic if the user setting exists and is enabled, and caller has not bypassed it
+  ' (bypassDoviPreservation is set when retrying after a buffer overflow to allow direct play)
+  if not bypassDoviPreservation and isValid(mediaStreams) and isValid(globalUser.settings.playbackPreserveDovi) and globalUser.settings.playbackPreserveDovi
     ' Check if device supports DOVI before proceeding
     deviceSupportsDovi = false
     di = CreateObject("roDeviceInfo")


### PR DESCRIPTION
## Problem

When **Preserve Dolby Vision** is enabled, JellyRock injects a `ContainerProfile` condition that forces Jellyfin to remux DoVi MKV files rather than direct play them. For content with significant bitrate spikes (Roku limits peaks to ~1.5× average bitrate), this remux can trigger a `buffer:loop:` error — Roku's internal signal that the HLS segment reservation has exceeded the device buffer. Previously this resulted in a generic playback error dialog with no recovery path.

## Solution

Detect the `buffer:loop:` error source and automatically retry with direct play by bypassing the DoVi container profile injection, allowing the server to re-evaluate the stream without the DoVi preservation constraint. Direct play avoids the remux overhead that amplifies the bitrate spike problem.

### What changed

**`Items.bs`** — `ItemPostPlaybackInfo` accepts a new `bypassDoviPreservation` flag. When set, the DoVi `ContainerProfile` condition is not added to the device profile, so the server evaluates the stream without it.

**`LoadVideoContentTask.xml / .bs`** — New `bypassDoviPreservation` task field threads the bypass flag from `VideoPlayerView` through the content loader down to `ItemPostPlaybackInfo`. When a transcode is caused by `VideoRangeTypeNotSupported` (the reason Jellyfin returns when the DoVi profile blocks an MKV), the task sets `video.doviDirectPlayFallbackAvailable = true` to signal to the player that a direct-play retry is viable.

**`VideoPlayerView.bs`** — The `onState("error")` handler now checks for a `buffer:loop:` error source combined with `doviDirectPlayFallbackAvailable`. On a match it:
1. Saves the current playback position
2. Sets `isRetrying = true` to guard against the scene being popped
3. Stops the player and re-runs `LoadVideoContentTask` with `bypassDoviPreservation = true`

**`VideoPlayerView.xml`** — Two new interface fields: `doviDirectPlayFallbackAvailable` (signals a viable direct-play fallback exists) and `isRetrying` (guards the ViewCreator lifecycle during retry).

**`ViewCreator.bs`** — `onStateChange` now skips `popScene` when `isRetrying` is true. Calling `m.top.control = "stop"` inside an error handler causes Roku to fire the `finished` state, which would otherwise pop the scene mid-retry.

## Test plan

- [x] Enable **Settings → Playback → Preserve Dolby Vision**
- [x] Play a DoVi MKV that previously triggered the `buffer:loop:` error (content with significant bitrate spikes)
- [x] Confirm no error dialog appears — expect log: `[WARN] Buffer overflow in DoVi transcode; falling back to direct play`
- [x] Confirm playback resumes via direct play from the saved position
- [x] Confirm only one retry attempt occurs (no retry loop if direct play also fails — error dialog shown instead)
- [x] Play non-DoVi content and confirm no change in behaviour
- [x] Change audio/subtitle tracks during playback and confirm no bypass state leaks across reloads