### PR TITLE
fix(JRRowItem): Season/Episode title order and MusicVideo slot

### DIFF
--- a/components/extras/ExtrasRowList.bs
+++ b/components/extras/ExtrasRowList.bs
@@ -283,16 +283,33 @@ end sub
 sub onLikeThisLoaded()
   data = m.LikeThisTask.content
   m.LikeThisTask.unobserveField("content")
+  itemType = m.top.type
   if isValid(data) and data.count() > 0
-    m.rowLikeThis = populateRow(m.rowLikeThis, tr("More Like This"), data, rowSlotSize.ROW_HEIGHT_PORTRAIT)
-    addRowSize(rowSlotSize.PORTRAIT)
+    ' MusicVideo and Video items are always landscape (≥4:3) and have no portrait posters —
+    ' use a wide slot so the image URL logic fetches Thumb/Backdrop instead of Primary.
+    if itemType = "MusicVideo" or itemType = "Video"
+      m.rowLikeThis = populateRow(m.rowLikeThis, tr("More Like This"), data, rowSlotSize.ROW_HEIGHT_WIDE)
+      ' Cannot use addRowSize() here. loadParts() seeds rowItemSize with a phantom PORTRAIT
+      ' element before any rows exist, which offsets all addRowSize() indices by one and would
+      ' leave this row still mapped to PORTRAIT. Instead, rebuild the array from the actual
+      ' content child count: PORTRAIT for every preceding row, WIDE for this (final) row.
+      newSizes = []
+      childCount = m.top.content.getChildCount()
+      for i = 0 to childCount - 2
+        newSizes.push(rowSlotSize.PORTRAIT)
+      end for
+      newSizes.push(rowSlotSize.WIDE)
+      m.top.rowItemSize = newSizes
+    else
+      m.rowLikeThis = populateRow(m.rowLikeThis, tr("More Like This"), data, rowSlotSize.ROW_HEIGHT_PORTRAIT)
+      addRowSize(rowSlotSize.PORTRAIT)
+    end if
   else if isValid(m.rowLikeThis)
     m.top.content.removeChild(m.rowLikeThis)
     m.rowLikeThis = invalid
   end if
 
   ' SpecialFeatures only for Movie / Video / Recording — not MusicVideo, Episode, Series, or Season
-  itemType = m.top.type
   if itemType <> "MusicVideo" and itemType <> "Episode" and itemType <> "Series" and itemType <> "Season"
     m.SpecialFeaturesTask.observeField("content", "onSpecialFeaturesLoaded")
     m.SpecialFeaturesTask.itemId = m.top.parentId

--- a/source/utils/rowItemText.bs
+++ b/source/utils/rowItemText.bs
@@ -2,8 +2,8 @@ import "pkg:/source/utils/misc.bs"
 
 ' Returns the primary display title for a row item.
 '
-' - Season: returns the series name (stored in subtitle by the transformer)
-' - Episode: returns the series name (item.seriesName)
+' - Season: returns the season label (item.name, e.g. "Season 1")
+' - Episode: returns the episode code and title (item.subtitle, e.g. "S1E2 - Pilot")
 ' - All others: returns item.name
 '
 ' @param item - JellyfinBaseItem content node
@@ -11,14 +11,15 @@ import "pkg:/source/utils/misc.bs"
 function getRowItemTitle(item as object) as string
   if not isValid(item) then return ""
 
-  ' Season: transformer stores seriesName in subtitle for primary display
+  ' Season: item.name is the season label; subtitle holds seriesName (shown as secondary text)
   if item.type = "Season"
-    return item.subtitle
+    return item.name
   end if
 
-  ' Episode: show the series name as the headline (episode title goes in subtitle)
+  ' Episode: subtitle holds the pre-computed episode code + title ("S1E2 - Name");
+  ' seriesName provides context and is shown as secondary text below.
   if item.type = "Episode"
-    return item.seriesName
+    return item.subtitle
   end if
 
   return item.name
@@ -26,18 +27,24 @@ end function
 
 ' Returns the secondary display subtitle for a row item.
 '
-' - Season: returns the season label ("Season 1", "Season 2", etc.) from item.name
+' - Season: returns the series name (stored in item.subtitle by the transformer)
+' - Episode: returns the series name (item.seriesName)
 ' - All others: returns the pre-computed subtitle field
-'   (e.g., "2024 • PG-13" for Movie, "S1E2 - Title" for Episode, "2020 - Present" for Series)
+'   (e.g., "2024 • PG-13" for Movie, "2020 - Present" for Series)
 '
 ' @param item - JellyfinBaseItem content node
 ' @returns Display subtitle string, or "" if item is invalid
 function getRowItemSubtitle(item as object) as string
   if not isValid(item) then return ""
 
-  ' Season: name holds "Season 1", subtitle holds seriesName (used as the title)
+  ' Season: subtitle field holds the series name; name holds "Season N" (shown as title)
   if item.type = "Season"
-    return item.name
+    return item.subtitle
+  end if
+
+  ' Episode: series name provides context for the episode code+title shown above
+  if item.type = "Episode"
+    return item.seriesName
   end if
 
   return item.subtitle

--- a/tests/source/unit/utils/rowItemText.spec.bs
+++ b/tests/source/unit/utils/rowItemText.spec.bs
@@ -13,24 +13,24 @@ namespace tests
     @describe("getRowItemTitle()")
     '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-    @it("returns seriesName for Episode")
+    @it("returns episode code and title (subtitle field) for Episode")
     function _()
       item = CreateObject("roSGNode", "JellyfinBaseItem")
       item.id = "ep1"
       item.type = "Episode"
+      item.subtitle = "S1E1 - Pilot"
       item.seriesName = "Breaking Bad"
-      item.name = "Pilot"
-      m.assertEqual(getRowItemTitle(item), "Breaking Bad")
+      m.assertEqual(getRowItemTitle(item), "S1E1 - Pilot")
     end function
 
-    @it("returns subtitle (seriesName) for Season")
+    @it("returns season label (name field) for Season")
     function _()
       item = CreateObject("roSGNode", "JellyfinBaseItem")
       item.id = "s1"
       item.type = "Season"
-      item.subtitle = "Breaking Bad" ' transformer stores seriesName in subtitle
       item.name = "Season 1"
-      m.assertEqual(getRowItemTitle(item), "Breaking Bad")
+      item.subtitle = "Breaking Bad" ' transformer stores seriesName in subtitle (shown below)
+      m.assertEqual(getRowItemTitle(item), "Season 1")
     end function
 
     @it("returns name for Movie")
@@ -83,46 +83,47 @@ namespace tests
       m.assertEqual(getRowItemTitle(invalid), "")
     end function
 
-    @it("returns empty string for Episode with no seriesName")
+    @it("returns empty string for Episode with no subtitle")
     function _()
       item = CreateObject("roSGNode", "JellyfinBaseItem")
       item.id = "ep1"
       item.type = "Episode"
-      ' seriesName defaults to "" in JellyfinBaseItem
+      ' subtitle defaults to "" in JellyfinBaseItem
       m.assertEqual(getRowItemTitle(item), "")
     end function
 
-    @it("returns empty string for Season with no subtitle (seriesName)")
+    @it("returns season name for Season regardless of subtitle field")
     function _()
       item = CreateObject("roSGNode", "JellyfinBaseItem")
       item.id = "s1"
       item.type = "Season"
-      ' subtitle defaults to "" in JellyfinBaseItem
       item.name = "Season 1"
-      m.assertEqual(getRowItemTitle(item), "")
+      ' subtitle may be empty (e.g. series name not yet populated) — title always comes from name
+      m.assertEqual(getRowItemTitle(item), "Season 1")
     end function
 
     '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
     @describe("getRowItemSubtitle()")
     '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-    @it("returns name (season label) for Season")
+    @it("returns series name (subtitle field) for Season")
     function _()
       item = CreateObject("roSGNode", "JellyfinBaseItem")
       item.id = "s1"
       item.type = "Season"
       item.name = "Season 1"
-      item.subtitle = "Breaking Bad"
-      m.assertEqual(getRowItemSubtitle(item), "Season 1")
+      item.subtitle = "Breaking Bad" ' transformer stores seriesName in subtitle
+      m.assertEqual(getRowItemSubtitle(item), "Breaking Bad")
     end function
 
-    @it("returns pre-computed subtitle for Episode")
+    @it("returns series name for Episode")
     function _()
       item = CreateObject("roSGNode", "JellyfinBaseItem")
       item.id = "ep1"
       item.type = "Episode"
       item.subtitle = "S1E2 - Cat's in the Bag"
-      m.assertEqual(getRowItemSubtitle(item), "S1E2 - Cat's in the Bag")
+      item.seriesName = "Breaking Bad"
+      m.assertEqual(getRowItemSubtitle(item), "Breaking Bad")
     end function
 
     @it("returns pre-computed subtitle for Movie")
@@ -166,15 +167,15 @@ namespace tests
       m.assertEqual(getRowItemSubtitle(item), "")
     end function
 
-    @it("Season subtitle is its own name, not the series name in subtitle field")
+    @it("Season subtitle returns series name from subtitle field, not its own name")
     function _()
       item = CreateObject("roSGNode", "JellyfinBaseItem")
       item.id = "s2"
       item.type = "Season"
       item.name = "Season 2"
       item.subtitle = "Breaking Bad"
-      ' Subtitle should return "Season 2" (name), NOT "Breaking Bad" (subtitle)
-      m.assertEqual(getRowItemSubtitle(item), "Season 2")
+      ' Subtitle should return "Breaking Bad" (series name), NOT "Season 2" (name, shown as title)
+      m.assertEqual(getRowItemSubtitle(item), "Breaking Bad")
     end function
 
   end class


### PR DESCRIPTION
## Changes

**Season/Episode title swap** (`rowItemText.bs`)
- Season tiles: primary line is now the season label ("Season 1"), secondary is the series name
- Episode tiles: primary line is now the episode code+title ("S1E2 - Name"), secondary is the series name
- Applies consistently across all contexts (home rows, extras, search)

**MusicVideo/Video More Like This slot** (`ExtrasRowList.bs`)
- More Like This row for MusicVideo and Video detail pages now uses a wide slot (468×264) so the image URL logic requests Thumb/Backdrop instead of Primary, correctly serving their landscape-only artwork
- `rowItemSize` is rebuilt from the actual content child count rather than using `addRowSize()`, which would place the size at the wrong index due to a phantom initial PORTRAIT element seeded by `loadParts()` before any rows exist

**Tests** (`rowItemText.spec.bs`)
- Updated all 6 tests that encoded the old Season/Episode behavior