### PR TITLE
feat: add destroy() to all remaining screens

### DIFF
--- a/components/ItemDetails.bs
+++ b/components/ItemDetails.bs
@@ -1876,3 +1876,58 @@ function onKeyEvent(key as string, press as boolean) as boolean
 
   return false
 end function
+
+' destroy: Full teardown releasing all resources before component removal
+' Called automatically by SceneManager.popScene() / clearScenes()
+sub destroy()
+  m.log.verbose("destroy")
+
+  ' Unobserve m.top programmatic observer (may or may not be active depending on flow)
+  m.top.unobserveField("itemContent")
+
+  ' Unobserve child node observers
+  m.itemLogo.unobserveField("loadStatus")
+  m.itemDetails.unobserveField("renderTracking")
+  m.extrasGrid.unobserveField("personHasMedia")
+  if isValid(m.clock)
+    m.clock.unobserveField("minutes")
+    m.clock = invalid
+  end if
+
+  ' Stop and release task nodes
+  m.loadFirstEpisodeTask.unobserveField("content")
+  m.loadFirstEpisodeTask.control = "STOP"
+  m.loadFirstEpisodeTask = invalid
+
+  m.loadSeriesResumeTask.unobserveField("content")
+  m.loadSeriesResumeTask.control = "STOP"
+  m.loadSeriesResumeTask = invalid
+
+  m.loadSeasonSeriesTask.unobserveField("content")
+  m.loadSeasonSeriesTask.control = "STOP"
+  m.loadSeasonSeriesTask = invalid
+
+  ' Clear node references
+  m.extrasGrp = invalid
+  m.extrasGrid = invalid
+  m.options = invalid
+  m.infoGroup = invalid
+  m.itemDescription = invalid
+  m.buttonGrp = invalid
+  m.itemLogo = invalid
+  m.dateCreatedLabel = invalid
+  m.itemTextGradient = invalid
+  m.itemDetails = invalid
+  m.itemTracks = invalid
+  m.itemDetailsSlider = invalid
+  m.itemDetailsSliderInterp = invalid
+  m.itemInfoRows = invalid
+  m.directorGenreGroup = invalid
+  m.optionsButton = invalid
+  m.shuffleButton = invalid
+  m.endsAtNode = invalid
+
+  ' Clear data caches
+  m.seasonSeriesCache = invalid
+  m.seasonSeriesData = invalid
+end sub

--- a/components/ItemGrid/BaseGridView.bs
+++ b/components/ItemGrid/BaseGridView.bs
@@ -926,14 +926,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
       optionsClosed()
       return true
     else
-      ' Cleanup presenter
-      if isValid(m.presenter)
-        m.presenter.destroy()
-        m.presenter = invalid
-      end if
-
       m.global.sceneManager.callfunc("popScene")
-      m.loadItemsTask.control = "stop"
       return true
     end if
   else if key = "play"
@@ -1047,4 +1040,52 @@ sub updateTitle()
   if m.showItemCount and m.loadItemsTask.totalRecordCount > 0 and lowerView <> "genres"
     m.top.overhangTitle += " (" + tr("%1 of %2").Replace("%1", actInt.toStr()).Replace("%2", m.loadItemsTask.totalRecordCount.toStr()) + ")"
   end if
+end sub
+
+' destroy: Full teardown releasing all resources before component removal
+' Called automatically by SceneManager.popScene() / clearScenes()
+sub destroy()
+  m.log.verbose("destroy")
+
+  ' Unobserve child node observers
+  m.genreList.unobserveField("rowItemFocused")
+  m.genreList.unobserveField("itemSelected")
+  m.itemGrid.unobserveField("itemFocused")
+  m.itemGrid.unobserveField("itemSelected")
+  m.voiceBox.unobserveField("text")
+
+  ' tvGuide may already be cleaned up by hideTvGuide() on back-press
+  if isValid(m.tvGuide)
+    m.tvGuide.unobserveField("watchChannel")
+    m.tvGuide.unobserveField("focusedChannel")
+    m.tvGuide = invalid
+  end if
+
+  ' Stop and release task node
+  m.loadItemsTask.unobserveField("content")
+  m.loadItemsTask.control = "STOP"
+  m.loadItemsTask.content = []
+  m.loadItemsTask = invalid
+
+  ' Destroy presenter class object (may already be invalid from back-press handler)
+  if isValid(m.presenter)
+    m.presenter.destroy()
+    m.presenter = invalid
+  end if
+
+  ' Clear node references
+  m.options = invalid
+  m.itemGrid = invalid
+  m.voiceBox = invalid
+  m.emptyText = invalid
+  m.alpha = invalid
+  m.alphaMenu = invalid
+  m.genreList = invalid
+  m.presentationBackdrop = invalid
+  m.presentationInfo = invalid
+  m.channelFocused = invalid
+
+  ' Release content nodes
+  m.data = invalid
+  m.genreData = invalid
 end sub

--- a/components/config/LoginScene.bs
+++ b/components/config/LoginScene.bs
@@ -1,6 +1,8 @@
+import "pkg:/source/roku_modules/log/LogMixin.brs"
 import "pkg:/source/utils/misc.bs"
 
 sub init()
+  m.log = log.Logger("LoginScene")
   m.top.setFocus(true)
   m.top.optionsAvailable = false
 
@@ -47,3 +49,14 @@ function onKeyEvent(key as string, press as boolean) as boolean
 
   return false
 end function
+
+' destroy: Full teardown releasing all resources before component removal
+' Called automatically by SceneManager.popScene() / clearScenes()
+sub destroy()
+  m.log.verbose("destroy")
+
+  ' Clear node references
+  m.list = invalid
+  m.checkbox = invalid
+  m.buttons = invalid
+end sub

--- a/components/config/SetServerScreen.bs
+++ b/components/config/SetServerScreen.bs
@@ -216,3 +216,35 @@ function onKeyEvent(key as string, press as boolean) as boolean
 
   return handled
 end function
+
+' destroy: Full teardown releasing all resources before component removal
+' Called automatically by SceneManager.popScene() / clearScenes()
+sub destroy()
+  m.log.verbose("destroy")
+
+  ' Unobserve m.top observer
+  m.top.unobserveField("serverUrl")
+
+  ' Dialog may or may not be open — unobserve and release if present
+  if isValid(m.dialog)
+    m.dialog.unobserveField("buttonSelected")
+    m.dialog = invalid
+  end if
+
+  ' Stop and release task node (created by ScanForServers on init)
+  if isValid(m.ssdpScanner)
+    m.ssdpScanner.unobserveField("content")
+    m.ssdpScanner.control = "STOP"
+    m.ssdpScanner = invalid
+  end if
+
+  ' Clear node references
+  m.serverPicker = invalid
+  m.serverUrlTextbox = invalid
+  m.serverUrlContainer = invalid
+  m.serverUrlOutline = invalid
+  m.buttons = invalid
+
+  ' Release server list data
+  m.servers = invalid
+end sub

--- a/components/home/Home.bs
+++ b/components/home/Home.bs
@@ -183,3 +183,17 @@ sub postFinished()
   m.log.decreaseIndent()
   m.log.verbose("Post task cleanup complete")
 end sub
+
+' destroy: Full teardown releasing all resources before component removal
+' Called automatically by SceneManager.popScene() / clearScenes()
+sub destroy()
+  m.log.verbose("destroy")
+
+  ' Stop and release task node (observer may already be cleared by postFinished())
+  m.postTask.unobserveField("responseCode")
+  m.postTask.control = "STOP"
+  m.postTask = invalid
+
+  ' Clear node references
+  m.homeRows = invalid
+end sub

--- a/components/liveTv/schedule.bs
+++ b/components/liveTv/schedule.bs
@@ -1,6 +1,8 @@
+import "pkg:/source/roku_modules/log/LogMixin.brs"
 import "pkg:/source/utils/misc.bs"
 
 sub init()
+  m.log = log.Logger("Schedule")
   m.EPGLaunchCompleteSignaled = false
   m.scheduleGrid = m.top.findNode("scheduleGrid")
   m.detailsPane = m.top.findNode("detailsPane")
@@ -306,10 +308,57 @@ function onKeyEvent(key as string, press as boolean) as boolean
     gridGrp.setFocus(true)
     return true
   else if key = "back"
-    m.LoadChannelsTask.control = "stop"
     m.global.sceneManager.callFunc("popScene")
     return true
   end if
 
   return false
 end function
+
+' destroy: Full teardown releasing all resources before component removal
+' Called automatically by SceneManager.popScene() / clearScenes()
+sub destroy()
+  m.log.verbose("destroy")
+
+  ' Unobserve child node observers
+  m.detailsPane.unobserveField("watchSelectedChannel")
+  m.detailsPane.unobserveField("recordSelectedChannel")
+  m.detailsPane.unobserveField("recordSeriesSelectedChannel")
+  m.scheduleGrid.unobserveField("programFocused")
+  m.scheduleGrid.unobserveField("programSelected")
+  m.scheduleGrid.unobserveField("leftEdgeTargetTime")
+
+  ' Stop and release always-present task node
+  m.LoadChannelsTask.unobserveField("channels")
+  m.LoadChannelsTask.control = "STOP"
+  m.LoadChannelsTask = invalid
+
+  ' Stop and release conditionally-created task nodes
+  if isValid(m.LoadScheduleTask)
+    m.LoadScheduleTask.unobserveField("schedule")
+    m.LoadScheduleTask.control = "STOP"
+    m.LoadScheduleTask = invalid
+  end if
+
+  if isValid(m.LoadProgramDetailsTask)
+    m.LoadProgramDetailsTask.unobserveField("programDetails")
+    m.LoadProgramDetailsTask.control = "STOP"
+    m.LoadProgramDetailsTask = invalid
+  end if
+
+  if isValid(m.RecordProgramTask)
+    m.RecordProgramTask.unobserveField("recordOperationDone")
+    m.RecordProgramTask.control = "STOP"
+    m.RecordProgramTask = invalid
+  end if
+
+  ' Clear node references
+  m.detailsPane = invalid
+  m.scheduleGrid = invalid
+  m.gridMoveAnimation = invalid
+  m.gridMoveAnimationPosition = invalid
+
+  ' Clear data structures
+  m.channelIndex = invalid
+  m.fullyLoadedProgramIds = invalid
+end sub

--- a/components/login/UserSelect.bs
+++ b/components/login/UserSelect.bs
@@ -55,15 +55,6 @@ end sub
 ' JRScreen hook called when the screen is hidden by the screen manager
 sub OnScreenHidden()
   m.log.info("UserSelect screen hidden - clearing backdrop")
-
-  ' Stop task to prevent wasted resources
-  m.brandingTask.control = "STOP"
-
-  ' Cleanup observers and reset task
-  m.global.server.unobserveFieldScoped("splashscreenEnabled")
-  m.brandingTask.unobserveFieldScoped("responseCode")
-  m.brandingTask.callFunc("empty")
-
   ' Clear backdrop using forceBackdrop to ensure it clears even before login
   m.global.sceneManager.callFunc("setBackgroundImage", "", true, true)
 end sub
@@ -181,3 +172,21 @@ function onKeyEvent(key as string, press as boolean) as boolean
   end if
   return false
 end function
+
+' destroy: Full teardown releasing all resources before component removal
+' Called automatically by SceneManager.popScene() / clearScenes()
+' Note: OnScreenHidden already cleared the backdrop; this handles task/ref cleanup.
+sub destroy()
+  m.log.verbose("destroy")
+
+  ' Stop branding task and unobserve all scoped fields
+  ' (may already be self-cleaned by task callbacks, guards are safe no-ops)
+  m.brandingTask.control = "STOP"
+  m.global.server.unobserveFieldScoped("splashscreenEnabled")
+  m.brandingTask.unobserveFieldScoped("responseCode")
+  m.brandingTask.callFunc("empty")
+  m.brandingTask = invalid
+
+  ' Clear node references
+  m.buttons = invalid
+end sub

--- a/components/music/AlbumView.bs
+++ b/components/music/AlbumView.bs
@@ -1,7 +1,9 @@
+import "pkg:/source/roku_modules/log/LogMixin.brs"
 import "pkg:/source/utils/itemImageUrl.bs"
 import "pkg:/source/utils/misc.bs"
 
 sub init()
+  m.log = log.Logger("AlbumView")
   m.top.optionsAvailable = false
   setupMainNode()
 
@@ -136,4 +138,21 @@ end sub
 sub onDoneLoading()
   m.songList.unobservefield("doneLoading")
   stopLoadingSpinner()
+end sub
+
+' destroy: Full teardown releasing all resources before component removal
+' Called automatically by SceneManager.popScene() / clearScenes()
+sub destroy()
+  m.log.verbose("destroy")
+
+  ' Unobserve child node observer (may already be cleared by onDoneLoading())
+  m.songList.unobserveField("doneLoading")
+
+  ' Clear node references
+  m.buttons = invalid
+  m.albumCover = invalid
+  m.songList = invalid
+  m.infoGroup = invalid
+  m.songListRect = invalid
+  m.dscr = invalid
 end sub

--- a/components/music/ArtistView.bs
+++ b/components/music/ArtistView.bs
@@ -1,8 +1,10 @@
 import "pkg:/source/constants/imageSize.bs"
+import "pkg:/source/roku_modules/log/LogMixin.brs"
 import "pkg:/source/utils/itemImageUrl.bs"
 import "pkg:/source/utils/misc.bs"
 
 sub init()
+  m.log = log.Logger("ArtistView")
   m.top.optionsAvailable = false
   setupMainNode()
   setupButtons()
@@ -225,3 +227,30 @@ function onKeyEvent(key as string, press as boolean) as boolean
 
   return false
 end function
+
+' destroy: Full teardown releasing all resources before component removal
+' Called automatically by SceneManager.popScene() / clearScenes()
+sub destroy()
+  m.log.verbose("destroy")
+
+  ' Unobserve all child node observers
+  m.appearsOn.unobserveField("escape")
+  m.appearsOn.unobserveField("MusicArtistAlbumData")
+  m.albums.unobserveField("escape")
+  m.albums.unobserveField("MusicArtistAlbumData")
+  m.sectionScroller.unobserveField("displayedIndex")
+  m.dscr.unobserveField("isTextEllipsized")
+  m.buttonGrp.unobserveField("buttonSelected")
+
+  ' Clear node references
+  m.albumHeader = invalid
+  m.appearsOnHeader = invalid
+  m.appearsOn = invalid
+  m.albums = invalid
+  m.sectionScroller = invalid
+  m.overhang = invalid
+  m.artistImage = invalid
+  m.dscr = invalid
+  m.buttonGrp = invalid
+  m.main = invalid
+end sub

--- a/components/music/AudioPlayerView.bs
+++ b/components/music/AudioPlayerView.bs
@@ -837,4 +837,59 @@ function onKeyEvent(key as string, press as boolean) as boolean
   return false
 end function
 
+' destroy: Full teardown releasing all resources before component removal
+' Called automatically by SceneManager.popScene() / clearScenes()
+sub destroy()
+  m.log.verbose("destroy")
 
+  ' Unobserve global audioPlayer fields (m.audioPlayer is m.global.audioPlayer — don't destroy it)
+  m.audioPlayer.unobserveField("state")
+  m.audioPlayer.unobserveField("position")
+  m.audioPlayer.unobserveField("bufferingStatus")
+
+  ' Unobserve button observer
+  m.buttons.unobserveField("buttonSelected")
+
+  ' Stop and release task nodes (observers may already be cleared by their callbacks)
+  m.LoadMetaDataTask.unobserveField("content")
+  m.LoadMetaDataTask.control = "STOP"
+  m.LoadMetaDataTask = invalid
+
+  m.LoadAudioStreamTask.unobserveField("content")
+  m.LoadAudioStreamTask.control = "STOP"
+  m.LoadAudioStreamTask = invalid
+
+  m.LoadScreenSaverTimeoutTask.unobserveField("content")
+  m.LoadScreenSaverTimeoutTask.control = "STOP"
+  m.LoadScreenSaverTimeoutTask = invalid
+
+  ' Release global node references (nulling local refs only — global nodes are unaffected)
+  m.audioPlayer = invalid
+  m.queueManager = invalid
+
+  ' Clear node references
+  m.buttons = invalid
+  m.playButton = invalid
+  m.shuffleButton = invalid
+  m.repeatButton = invalid
+  m.albumCover = invalid
+  m.playPosition = invalid
+  m.bufferPosition = invalid
+  m.seekBar = invalid
+  m.thumb = invalid
+  m.positionTimestamp = invalid
+  m.seekPosition = invalid
+  m.seekTimestamp = invalid
+  m.totalLengthTimestamp = invalid
+  m.playPositionAnimation = invalid
+  m.playPositionAnimationWidth = invalid
+  m.bufferPositionAnimation = invalid
+  m.bufferPositionAnimationWidth = invalid
+  m.screenSaverBackground = invalid
+  m.screenSaverAlbumCover = invalid
+  m.screenSaverAlbumAnimation = invalid
+  m.screenSaverAlbumCoverFadeIn = invalid
+  m.PosterOne = invalid
+  m.BounceAnimation = invalid
+  m.PosterOneFadeIn = invalid
+end sub

--- a/components/music/PlaylistView.bs
+++ b/components/music/PlaylistView.bs
@@ -1,7 +1,9 @@
+import "pkg:/source/roku_modules/log/LogMixin.brs"
 import "pkg:/source/utils/itemImageUrl.bs"
 import "pkg:/source/utils/misc.bs"
 
 sub init()
+  m.log = log.Logger("PlaylistView")
   m.top.optionsAvailable = false
   setupMainNode()
 
@@ -153,4 +155,22 @@ end sub
 sub onDoneLoading()
   m.songList.unobservefield("doneLoading")
   stopLoadingSpinner()
+end sub
+
+' destroy: Full teardown releasing all resources before component removal
+' Called automatically by SceneManager.popScene() / clearScenes()
+sub destroy()
+  m.log.verbose("destroy")
+
+  ' Unobserve child node observers (doneLoading may already be cleared by onDoneLoading())
+  m.songList.unobserveField("doneLoading")
+  m.songList.unobserveField("itemFocused")
+
+  ' Clear node references
+  m.buttons = invalid
+  m.albumCover = invalid
+  m.songList = invalid
+  m.infoGroup = invalid
+  m.songListRect = invalid
+  m.dscr = invalid
 end sub

--- a/components/photos/PhotoDetails.bs
+++ b/components/photos/PhotoDetails.bs
@@ -1,7 +1,9 @@
+import "pkg:/source/roku_modules/log/LogMixin.brs"
 import "pkg:/source/utils/config.bs"
 import "pkg:/source/utils/misc.bs"
 
 sub init()
+  m.log = log.Logger("PhotoDetails")
   m.top.optionsAvailable = true
   m.top.overhangVisible = false
   m.slideshowTimer = m.top.findNode("slideshowTimer")
@@ -161,6 +163,35 @@ function onKeyEvent(key as string, press as boolean) as boolean
 
   return false
 end function
+
+' destroy: Full teardown releasing all resources before component removal
+' Called automatically by SceneManager.popScene() / clearScenes()
+sub destroy()
+  m.log.verbose("destroy")
+
+  ' Unobserve timer observers
+  m.slideshowTimer.unobserveField("fire")
+  m.statusTimer.unobserveField("fire")
+
+  ' Stop timers (may already be stopped by OnScreenHidden or user interaction)
+  m.slideshowTimer.control = "stop"
+  m.statusTimer.control = "stop"
+
+  ' Stop and release task node (may be invalid if photo loading hadn't started)
+  if isValid(m.LoadLibrariesTask)
+    m.LoadLibrariesTask.unobserveField("results")
+    m.LoadLibrariesTask.control = "STOP"
+    m.LoadLibrariesTask = invalid
+  end if
+
+  ' Clear node references
+  m.slideshowTimer = invalid
+  m.status = invalid
+  m.textBackground = invalid
+  m.statusTimer = invalid
+  m.showStatusAnimation = invalid
+  m.hideStatusAnimation = invalid
+end sub
 
 function isValidToContinue(index as integer)
   if isValid(m.top.itemsNode)

--- a/components/search/SearchResults.bs
+++ b/components/search/SearchResults.bs
@@ -2,12 +2,14 @@ import "pkg:/source/api/baserequest.bs"
 import "pkg:/source/api/Image.bs"
 import "pkg:/source/api/Items.bs"
 import "pkg:/source/constants/imageSize.bs"
+import "pkg:/source/roku_modules/log/LogMixin.brs"
 import "pkg:/source/utils/config.bs"
 import "pkg:/source/utils/deviceCapabilities.bs"
 import "pkg:/source/utils/itemImageUrl.bs"
 import "pkg:/source/utils/misc.bs"
 
 sub init()
+  m.log = log.Logger("SearchResults")
   ' Clear backdrop immediately when search screen opens
   m.global.sceneManager.callFunc("setBackgroundImage", "")
 
@@ -144,3 +146,23 @@ function onKeyEvent(key as string, press as boolean) as boolean
 
   return false
 end function
+
+' destroy: Full teardown releasing all resources before component removal
+' Called automatically by SceneManager.popScene() / clearScenes()
+sub destroy()
+  m.log.verbose("destroy")
+
+  ' Unobserve child node observers
+  m.searchAlphabox.unobserveField("focusedChild")
+  m.searchSelect.unobserveField("rowItemFocused")
+
+  ' Stop and release task node (observer may already be cleared by loadResults())
+  m.searchTask.unobserveField("results")
+  m.searchTask.control = "STOP"
+  m.searchTask = invalid
+
+  ' Clear node references
+  m.searchSelect = invalid
+  m.searchAlphabox = invalid
+  m.searchHelpText = invalid
+end sub

--- a/components/settings/settings.bs
+++ b/components/settings/settings.bs
@@ -389,3 +389,42 @@ function onKeyEvent(key as string, press as boolean) as boolean
 
   return false
 end function
+
+' destroy: Full teardown releasing all resources before component removal
+' Called automatically by SceneManager.popScene() / clearScenes()
+sub destroy()
+  m.log.verbose("destroy")
+
+  ' Unobserve all child node observers
+  m.integerSetting.unobserveField("submit")
+  m.integerSetting.unobserveField("escape")
+  m.hexSetting.unobserveField("submit")
+  m.hexSetting.unobserveField("escape")
+  m.hexSetting.unobserveField("reset")
+  m.settingsMenu.unobserveField("itemFocused")
+  m.settingsMenu.unobserveField("itemSelected")
+  m.boolSetting.unobserveField("checkedItem")
+  m.radioSetting.unobserveField("checkedItem")
+
+  ' Unobserve scoped observer on sceneManager (may be active if reset dialog was open)
+  m.global.sceneManager.unobserveFieldScoped("dataReturned")
+
+  ' Stop and release postTask (observer may already be cleared by postFinished())
+  m.postTask.unobserveField("responseCode")
+  m.postTask.control = "STOP"
+  m.postTask = invalid
+
+  ' Clear node references
+  m.settingsMenu = invalid
+  m.settingDetail = invalid
+  m.settingDesc = invalid
+  m.path = invalid
+  m.boolSetting = invalid
+  m.integerSetting = invalid
+  m.radioSetting = invalid
+  m.hexSetting = invalid
+
+  ' Clear data structures
+  m.userLocation = invalid
+  m.configTree = invalid
+end sub

--- a/components/video/OSD.bs
+++ b/components/video/OSD.bs
@@ -1,6 +1,8 @@
+import "pkg:/source/roku_modules/log/LogMixin.brs"
 import "pkg:/source/utils/misc.bs"
 
 sub init()
+  m.log = log.Logger("OSD")
   m.inactivityTimer = m.top.findNode("inactivityTimer")
   m.endsAtTime = m.top.findNode("endsAtTime")
   m.videoLogo = m.top.findNode("videoLogo")
@@ -484,3 +486,43 @@ function onKeyEvent(key as string, press as boolean) as boolean
 
   return false
 end function
+
+' destroy: Full teardown releasing all resources before component removal
+' Called by VideoPlayerView.destroy() since OSD is a child component, not a SceneManager scene
+sub destroy()
+  m.log.verbose("destroy")
+
+  ' Unobserve all m.top observers
+  m.top.unobserveField("itemData")
+  m.top.unobserveField("visible")
+  m.top.unobserveField("hasFocus")
+  m.top.unobserveField("progressPercentage")
+  m.top.unobserveField("playbackState")
+
+  ' Unobserve clock (guarded — may be invalid if clock node not found in init)
+  if isValid(m.clock)
+    m.clock.unobserveField("minutes")
+    m.clock = invalid
+  end if
+
+  ' Stop inactivity timer (may already be stopped by onVisibleChanged)
+  m.inactivityTimer.unobserveField("fire")
+  m.inactivityTimer.control = "stop"
+  m.inactivityTimer = invalid
+
+  ' Clear node references
+  m.endsAtTime = invalid
+  m.videoLogo = invalid
+  m.videoTitle = invalid
+  m.videoSubtitleGroup = invalid
+  m.videoPlayPause = invalid
+  m.videoPositionTime = invalid
+  m.videoRemainingTime = invalid
+  m.progressBar = invalid
+  m.progressBarBackground = invalid
+  m.buttonMenuRight = invalid
+  m.buttonMenuLeft = invalid
+
+  ' Release cached item data reference
+  m.itemData = invalid
+end sub

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -1230,6 +1230,7 @@ sub destroy()
 
   if isValid(m.osd)
     m.osd.unobserveField("action")
+    m.osd.callFunc("destroy")
   end if
 
   ' Stop and release timers


### PR DESCRIPTION

## Changes
- Add the destroy() lifecycle method to all screens that were missing it, ensuring consistent resource cleanup when SceneManager pops or clears scenes.
