### PR TITLE
fix: bslint build warnings 

### DIFF
--- a/components/JRGroup.bs
+++ b/components/JRGroup.bs
@@ -1,8 +1,0 @@
-sub init()
-end sub
-
-function onKeyEvent(key as string, press as boolean) as boolean
-  if not press then return false
-
-  return false
-end function

--- a/components/JRMessageDialog.bs
+++ b/components/JRMessageDialog.bs
@@ -8,7 +8,7 @@ sub init()
   options.setFocus(true)
 end sub
 
-function onKeyEvent(key as string, press as boolean) as boolean
+function onKeyEvent(key as string, _press as boolean) as boolean
   if key = "back"
     m.top.backPressed = true
     return true

--- a/components/PlaybackDialog.bs
+++ b/components/PlaybackDialog.bs
@@ -1,4 +1,4 @@
-function onKeyEvent(key as string, press as boolean) as boolean
+function onKeyEvent(key as string, _press as boolean) as boolean
 
   if key = "OK"
     m.top.close = true

--- a/components/login/UserRow.bs
+++ b/components/login/UserRow.bs
@@ -46,9 +46,3 @@ end function
 sub setUser()
   m.top.userSelected = m.top.itemContent[m.top.rowItemFocused[1]].Name
 end sub
-
-function onKeyEvent(key as string, press as boolean) as boolean
-  if not press then return false
-
-  return false
-end function

--- a/components/testing/MockSceneManager.bs
+++ b/components/testing/MockSceneManager.bs
@@ -8,7 +8,7 @@ end sub
 
 ' Stub implementations - do nothing but exist so callFunc doesn't crash
 
-sub pushScene(newGroup)
+sub pushScene(_newGroup)
 end sub
 
 sub popScene()
@@ -39,16 +39,16 @@ end sub
 sub resetTime()
 end sub
 
-sub setBackgroundImage(url as string, fade = false as boolean, alwaysShow = false as boolean)
+sub setBackgroundImage(_url as string, _fade = false as boolean, _alwaysShow = false as boolean)
 end sub
 
-sub userMessage(title as string, message as string)
+sub userMessage(_title as string, _message as string)
 end sub
 
-sub standardDialog(title as string, content as object)
+sub standardDialog(_title as string, _content as object)
 end sub
 
-sub radioDialog(title as string, content as object)
+sub radioDialog(_title as string, _content as object)
 end sub
 
 sub dismissDialog()
@@ -58,5 +58,5 @@ function isDialogOpen() as boolean
   return false
 end function
 
-sub optionDialog(title as string, message as string, options as object)
+sub optionDialog(_title as string, _message as string, _options as object)
 end sub

--- a/source/GridView/GenericPresenter.bs
+++ b/source/GridView/GenericPresenter.bs
@@ -18,7 +18,7 @@ class GenericPresenter extends GridPresenterBase
   end function
 
   ' No presentation info for generic view
-  override function shouldShowPresentationInfo(viewMode as string) as boolean
+  override function shouldShowPresentationInfo(_viewMode as string) as boolean
     return false
   end function
 
@@ -80,7 +80,7 @@ class GenericPresenter extends GridPresenterBase
   end function
 
   ' Standard grid layout
-  override function getGridConfig(viewMode as string) as object
+  override function getGridConfig(_viewMode as string) as object
     return {
       translation: [96, 102],
       itemSize: [264, 396],
@@ -91,7 +91,7 @@ class GenericPresenter extends GridPresenterBase
     }
   end function
 
-  override sub configureLoadTask(task as object, parentItem as object, viewMode as string)
+  override sub configureLoadTask(task as object, _parentItem as object, _viewMode as string)
     ' Generic presenter uses whatever item type is in the folder
     task.recursive = false
   end sub

--- a/source/GridView/GridPresenterBase.bs
+++ b/source/GridView/GridPresenterBase.bs
@@ -50,7 +50,7 @@ class GridPresenterBase
   ' Returns the options configuration for ItemGridOptions
   ' @param {object} parentItem - The library item being displayed
   ' @return {object} Options object with views, sort, filter arrays
-  function getOptions(parentItem as object) as object
+  function getOptions(_parentItem as object) as object
     return {
       views: [],
       sort: [],
@@ -61,7 +61,7 @@ class GridPresenterBase
   ' Called when options dialog is closed
   ' Override to handle presenter-specific option changes
   ' @param {object} options - The ItemGridOptions component
-  sub onOptionsClosed(options as object)
+  sub onOptionsClosed(_options as object)
     ' Override in subclass
   end sub
 
@@ -73,7 +73,7 @@ class GridPresenterBase
   ' @param {object} task - The LoadItemsTask2 node
   ' @param {object} parentItem - The library item being displayed
   ' @param {string} viewMode - Current view mode (e.g., "Movies", "MoviesGrid")
-  sub configureLoadTask(task as object, parentItem as object, viewMode as string)
+  sub configureLoadTask(_task as object, _parentItem as object, _viewMode as string)
     ' Override in subclass
   end sub
 
@@ -96,7 +96,7 @@ class GridPresenterBase
   '   - numRows: string number of visible rows
   '   - numColumns: string number of columns
   '   - imageDisplayMode: "scaleToZoom" | "scaleToFit"
-  function getGridConfig(viewMode as string) as object
+  function getGridConfig(_viewMode as string) as object
     return {
       translation: [96, 60],
       itemSize: [264, 396],
@@ -110,7 +110,7 @@ class GridPresenterBase
   ' Returns whether to show presentation info panel for the view mode
   ' @param {string} viewMode - Current view mode
   ' @return {boolean} True to show info panel
-  function shouldShowPresentationInfo(viewMode as string) as boolean
+  function shouldShowPresentationInfo(_viewMode as string) as boolean
     return false
   end function
 
@@ -122,7 +122,7 @@ class GridPresenterBase
   ' Override to update presentation info display
   ' @param {object} item - The focused ContentNode item
   ' @param {string} currentView - The current view mode (e.g., "Movies", "MoviesGrid")
-  sub onItemFocused(item as object, currentView as string)
+  sub onItemFocused(_item as object, _currentView as string)
     ' Override in subclass
   end sub
 
@@ -133,7 +133,7 @@ class GridPresenterBase
   ' Creates presenter-specific info nodes in the presentationInfo group
   ' Called during onInit() if presenter needs custom info display
   ' @param {object} infoGroup - The presentationInfo Group node
-  sub createInfoNodes(infoGroup as object)
+  sub createInfoNodes(_infoGroup as object)
     ' Override in subclass
   end sub
 

--- a/source/GridView/LiveTVPresenter.bs
+++ b/source/GridView/LiveTVPresenter.bs
@@ -30,11 +30,11 @@ class LiveTVPresenter extends GridPresenterBase
   end function
 
   ' No presentation info for LiveTV
-  override function shouldShowPresentationInfo(viewMode as string) as boolean
+  override function shouldShowPresentationInfo(_viewMode as string) as boolean
     return false
   end function
 
-  override function getOptions(parentItem as object) as object
+  override function getOptions(_parentItem as object) as object
     return {
       views: [
         { "Title": tr("Channels"), "Name": "livetv" },
@@ -51,7 +51,7 @@ class LiveTVPresenter extends GridPresenterBase
   end function
 
   ' Channel logos need scaleToFit, not scaleToZoom
-  override function getGridConfig(viewMode as string) as object
+  override function getGridConfig(_viewMode as string) as object
     return {
       translation: [96, 102],
       itemSize: [264, 396],
@@ -62,7 +62,7 @@ class LiveTVPresenter extends GridPresenterBase
     }
   end function
 
-  override sub configureLoadTask(task as object, parentItem as object, viewMode as string)
+  override sub configureLoadTask(task as object, _parentItem as object, _viewMode as string)
     ' CRITICAL: itemType must be "LiveTV" to route to the LiveTv/Channels API endpoint
     ' (see LoadItemsTask2.bs line 113-115)
     task.itemType = "LiveTV"

--- a/source/GridView/PhotoPresenter.bs
+++ b/source/GridView/PhotoPresenter.bs
@@ -31,13 +31,13 @@ class PhotoPresenter extends GridPresenterBase
   end function
 
   ' No presentation info for photos
-  override function shouldShowPresentationInfo(viewMode as string) as boolean
+  override function shouldShowPresentationInfo(_viewMode as string) as boolean
     return false
   end function
 
   ' Photo view options control slideshow and random behavior
   ' These are unusual - 4 options that set 2 boolean flags
-  override function getOptions(parentItem as object) as object
+  override function getOptions(_parentItem as object) as object
     return {
       views: [
         { "Title": tr("Slideshow Off"), "Name": "singlephoto" },
@@ -81,7 +81,7 @@ class PhotoPresenter extends GridPresenterBase
     end if
   end sub
 
-  override function getGridConfig(viewMode as string) as object
+  override function getGridConfig(_viewMode as string) as object
     return {
       translation: [96, 102],
       itemSize: [264, 396],
@@ -92,7 +92,7 @@ class PhotoPresenter extends GridPresenterBase
     }
   end function
 
-  override sub configureLoadTask(task as object, parentItem as object, viewMode as string)
+  override sub configureLoadTask(task as object, parentItem as object, _viewMode as string)
     task.itemType = "Photo"
     task.itemId = parentItem.Id
     ' Photos in albums are non-recursive

--- a/tests/source/unit/utils/DeviceCapabilities.spec.bs
+++ b/tests/source/unit/utils/DeviceCapabilities.spec.bs
@@ -149,7 +149,7 @@ namespace tests
     @it("detects false positive for aac >6ch")
     function _()
       mockDi = {
-        CanDecodeAudio: function(params as object) as object
+        CanDecodeAudio: function(_params as object) as object
           return { Result: true } ' API says yes (false positive)
         end function
       }
@@ -161,7 +161,7 @@ namespace tests
     @it("detects false positive for pcm >2ch")
     function _()
       mockDi = {
-        CanDecodeAudio: function(params as object) as object
+        CanDecodeAudio: function(_params as object) as object
           return { Result: true } ' False positive
         end function
       }
@@ -173,7 +173,7 @@ namespace tests
     @it("detects false positive for lpcm >2ch")
     function _()
       mockDi = {
-        CanDecodeAudio: function(params as object) as object
+        CanDecodeAudio: function(_params as object) as object
           return { Result: true } ' False positive
         end function
       }
@@ -189,7 +189,7 @@ namespace tests
     @it("returns true for supported stereo codec (mp3 2ch)")
     function _()
       mockDi = {
-        CanDecodeAudio: function(params as object) as object
+        CanDecodeAudio: function(_params as object) as object
           return { Result: true }
         end function
       }
@@ -201,7 +201,7 @@ namespace tests
     @it("returns false when API says codec not supported")
     function _()
       mockDi = {
-        CanDecodeAudio: function(params as object) as object
+        CanDecodeAudio: function(_params as object) as object
           return { Result: false }
         end function
       }
@@ -213,7 +213,7 @@ namespace tests
     @it("returns true for aac 2ch (within limits)")
     function _()
       mockDi = {
-        CanDecodeAudio: function(params as object) as object
+        CanDecodeAudio: function(_params as object) as object
           return { Result: true }
         end function
       }
@@ -225,7 +225,7 @@ namespace tests
     @it("returns true for aac 6ch (at limit)")
     function _()
       mockDi = {
-        CanDecodeAudio: function(params as object) as object
+        CanDecodeAudio: function(_params as object) as object
           return { Result: true }
         end function
       }
@@ -262,7 +262,7 @@ namespace tests
     @it("returns empty array when no codecs are supported")
     function _()
       mockDi = {
-        CanDecodeAudio: function(params as object) as object
+        CanDecodeAudio: function(_params as object) as object
           return { Result: false } ' None supported
         end function
       }
@@ -446,7 +446,7 @@ namespace tests
     @it("dtshd is passthrough-only: returns false at >2ch when PassThru is not supported")
     function _()
       mockDi = {
-        CanDecodeAudio: function(params as object) as object
+        CanDecodeAudio: function(_params as object) as object
           ' Device has no receiver — PassThru not supported
           return { Result: false }
         end function


### PR DESCRIPTION

## Changes
- remove dead code
- prefix unused vars with an underscore to prevent warning

## Issues
Fixes #388
