### PR TITLE
fix: dismiss stale segment notifications on back-to-back transitions

### DIFF
--- a/components/video/VideoNotification.bs
+++ b/components/video/VideoNotification.bs
@@ -25,26 +25,27 @@ sub onActionButtonReady()
   end if
 end sub
 
-' Show the notification: position bottom-right with 5% safe zone, fade in, set focus
+' Show the notification: position bottom-right with 5% safe zone, fade in, set focus.
+' Safe to call while already showing — restarts the auto-dismiss timer and repositions
+' for updated text/autoDismissSeconds (e.g. contiguous segment transitions).
 sub show()
-  if m.top.state = "showing" then return
-
   m.log.info("Showing notification", m.top.text)
-  m.top.state = "showing"
   m.top.action = ""
 
-  ' Stop any in-progress fade out
+  ' Stop any in-progress timers and animations
+  m.autoDismissTimer.control = "stop"
   m.fadeOutAnimation.control = "stop"
 
-  ' Make visible so button can render and we can measure it
-  m.actionButton.visible = true
+  ' Only fade in and grab focus when not already visible
+  if m.top.state <> "showing"
+    m.top.state = "showing"
+    m.actionButton.visible = true
+    m.fadeInAnimation.control = "start"
+    m.actionButton.setFocus(true)
+  end if
 
-  ' Position to bottom-right with 5% safe zone padding
+  ' Reposition in case text width changed
   positionBottomRight()
-
-  ' Start fade-in animation
-  m.fadeInAnimation.control = "start"
-  m.actionButton.setFocus(true)
 
   ' Start auto-dismiss timer if configured
   if m.top.autoDismissSeconds > 0

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -923,6 +923,11 @@ sub checkMediaSegments()
         return
       end if
 
+      ' Dismiss notification from a prior segment (e.g. back-to-back askToSkip → skip)
+      if isNotificationVisible(m.segmentNotification) or m.segmentNotification.state = "paused"
+        m.segmentNotification.callFunc("dismiss")
+      end if
+
       m.log.info("Auto-skipping segment", segmentType, "to", seekPosition)
       m.top.seek = seekPosition
       m.skippedSegments[segmentId] = true
@@ -958,8 +963,13 @@ sub checkMediaSegments()
         m.segmentNotification.visible = true
         m.segmentNotification.callFunc("show")
       end if
+    else
+      ' MediaSegmentAction.none — dismiss stale notification from a prior segment
+      if isNotificationVisible(m.segmentNotification) or m.segmentNotification.state = "paused"
+        m.segmentNotification.callFunc("dismiss")
+      end if
+      m.activeSegmentId = ""
     end if
-    ' MediaSegmentAction.none — do nothing
   else
     ' Not inside any segment — dismiss segment notification if visible or paused
     if isNotificationVisible(m.segmentNotification) or m.segmentNotification.state = "paused"


### PR DESCRIPTION
## Summary
- Make `show()` idempotent for contiguous segment transitions (restart timers, reposition without re-triggering fade-in)
- Dismiss stale notifications in skip/none action branches to prevent lingering UI from a prior askToSkip segment

Merged #447 before I could push these