### PR TITLE
Refactor: OptionsSlider to not extend PanelSet

### DIFF
--- a/components/JRScene.xml
+++ b/components/JRScene.xml
@@ -4,6 +4,8 @@
     <BackdropFader id="imageFader" translation="[0, 0]" />
     <Group id="content" />
     <JROverhang id="overhang" />
+    <!-- Container for OptionsSlider when open, rendered above overhang for correct z-order -->
+    <Group id="optionsPanelOverlay" />
     <LabelPrimaryLarge id="loadingText" height="225" width="1266" horizAlign="center" vertAlign="bottom" wrap="true" translation="[327, 210]" visible="false" />
     <Spinner id="spinner" translation="[897, 477]" />
     <Toast id="toast" visible="false" />

--- a/components/options/OptionsSlider.bs
+++ b/components/options/OptionsSlider.bs
@@ -1,16 +1,35 @@
 sub init()
   m.top.visible = false
 
-  panel = m.top.findNode("panel")
-  panel.panelSize = "small"
-  panel.leftPosition = 96
-  panel.focusable = true
-  panel.hasNextPanel = false
-  panel.leftOnly = true
+  m.sliderGroup = m.top.findNode("sliderGroup")
+  m.slideInAnim = m.top.findNode("slideInAnim")
+  m.slideInInterp = m.top.findNode("slideInInterp")
+  m.panelOverlay = m.top.getScene().findNode("optionsPanelOverlay")
 
-  list = m.top.findNode("panelList")
+  constants = m.global.constants
+  m.top.findNode("backdrop").color = constants.colorBlack + constants.alpha90
 
-  panel.list = list
+  m.top.observeField("visible", "onVisibleChanged")
+end sub
+
+sub onVisibleChanged()
+  if m.top.visible
+    ' Reparent to overlay container (after overhang in JRScene) for correct z-order
+    m.originalParent = m.top.getParent()
+    m.panelOverlay.appendChild(m.top)
+    ' Animate slide-in from left
+    m.slideInInterp.keyValue = [[-700, 0], [0, 0]]
+    m.slideInAnim.control = "start"
+  else
+    ' Reset position to off-screen for next open
+    m.slideInAnim.control = "stop"
+    m.sliderGroup.translation = [-700, 0]
+    ' Reparent back to original screen
+    if m.originalParent <> invalid
+      m.originalParent.appendChild(m.top)
+      m.originalParent = invalid
+    end if
+  end if
 end sub
 
 sub setFields()

--- a/components/options/OptionsSlider.xml
+++ b/components/options/OptionsSlider.xml
@@ -1,17 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
-<component name="OptionsSlider" extends="PanelSet">
+<component name="OptionsSlider" extends="Group">
   <children>
-    <ListPanel id="panel">
+    <!-- Wrapper group animated for slide in/out. Starts off-screen left. -->
+    <Group id="sliderGroup" translation="[-700, 0]">
+      <!-- Color set in OptionsSlider.bs init() from constants (colorBlack + alpha90) -->
       <Rectangle id="backdrop"
-        translation="[0, 0]"
-        color="#101010DD"
-        width="575"
+        width="700"
         height="1080" />
-      <LabelList id="panelList">
+      <LabelList id="panelList"
+        translation="[132, 175]"
+        itemSize="[510, 66]"
+        numRows="10"
+        drawFocusFeedback="true">
         <ContentNode id="fieldList" role="content" />
       </LabelList>
-    </ListPanel>
+    </Group>
+
+    <!-- Slide-in animation following ExtrasSlider pattern -->
+    <Animation id="slideInAnim" duration="0.25" repeat="false" easeFunction="outCubic">
+      <!-- keyValue set in OptionsSlider.bs before each animation start -->
+      <Vector2DFieldInterpolator id="slideInInterp"
+        key="[0.0, 1.0]"
+        fieldToInterp="sliderGroup.translation" />
+    </Animation>
   </children>
+
   <interface>
     <field id="buttons" type="nodearray" onChange="setFields" />
     <field id="options" type="nodearray" onChange="setFields" />

--- a/source/Main.bs
+++ b/source/Main.bs
@@ -729,8 +729,9 @@ sub Main (args as dynamic) as void
       actionId = button.id
 
       ' Close the side panel before handling the action
+      ' Search from scene — panel may be reparented to optionsPanelOverlay while open
       if isValid(group)
-        panel = group.findNode("options")
+        panel = m.scene.findNode("options")
         if isValid(panel)
           panel.visible = false
         end if


### PR DESCRIPTION
Replaces the built-in Roku `PanelSet` base component with a plain `Group` and manual slide animation, giving us full control over layout, animation, and z-ordering.

## Changes

- **OptionsSlider.xml**: Extends `Group` instead of `PanelSet`. Replaces `ListPanel` with a wrapper `Group` containing a `Rectangle` backdrop and `LabelList`, plus a `Vector2DFieldInterpolator` slide-in animation
- **OptionsSlider.bs**: Removes PanelSet configuration (`panelSize`, `leftPosition`, etc.). Adds `onVisibleChanged` observer that drives the slide animation and reparents the panel to a JRScene overlay container for correct z-ordering above the overhang
- **JRScene.xml**: Adds `optionsPanelOverlay` container after the overhang node so the options panel backdrop renders above the overhang when open
- **Main.bs**: Updates `optionSelected` handler to search for the options panel from `m.scene` instead of the active group, since the panel may be reparented to the overlay while open
- Backdrop uses `constants.colorBlack + constants.alpha90` instead of a hardcoded color