### PR TITLE
fix: explicitly mark episode as watched when skipping outro

### DIFF
--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -898,14 +898,23 @@ end sub
 ' Triggers synchronous teardown (onState -> ViewCreator -> popScene -> destroy),
 ' invalidating all m. references. Callers MUST return immediately after calling.
 sub forceFinishPlayback()
-  m.log.info("Force-finishing playback — marking as watched", m.top.id)
-
   ' Explicitly mark as watched via dedicated API endpoint.
   ' Uses the API pool (not SideEffectTask) so it can't be overwritten
   ' by the playstate report that fires during teardown.
   if m.top.id <> ""
     req = GetApi().BuildMarkPlayedRequest(m.top.id)
-    if isValid(req) then submitApiRequest(req, "forceFinishMarkPlayed")
+    if isValid(req)
+      resultNode = submitApiRequest(req, "forceFinishMarkPlayed")
+      if isValid(resultNode)
+        m.log.info("Force-finishing playback — marking as watched", m.top.id)
+      else
+        m.log.warn("Force-finishing playback — API pool not ready, mark-played dropped", m.top.id)
+      end if
+    else
+      m.log.warn("Force-finishing playback — could not build mark-played request", m.top.id)
+    end if
+  else
+    m.log.info("Force-finishing playback — no item ID, skipping mark-played")
   end if
 
   m.top.control = "stop"


### PR DESCRIPTION
Skipping an outro that ends near the video end calls `forceFinishPlayback()`, which relied on `ReportPlayback("finished")` to mark the episode as watched. For episodes with longer outros, the reported playback position (at the outro start) didn't meet the server's default watched threshold — so the server never marked those episodes as played.

## Changes

- Call `BuildMarkPlayedRequest()` in `forceFinishPlayback()` to explicitly mark the item as played via the `UserPlayedItems` endpoint, regardless of playback position
- Route the request through the API pool (`submitApiRequest`) instead of `SideEffectTask` so it can't be overwritten by the playstate report that fires during teardown
- Guard against empty item ID before submitting the request