### PR TITLE
fix: API timeouts + TV Guide performance + quickplay

### DIFF
--- a/components/ItemGrid/BaseGridView.bs
+++ b/components/ItemGrid/BaseGridView.bs
@@ -181,6 +181,7 @@ sub showTVGuide()
   ' Hide the grid and show the guide
   m.itemGrid.visible = false
   m.top.appendChild(m.tvGuide)
+  m.tvGuide.callFunc("startLoading")
   m.tvGuide.lastFocus.setFocus(true)
   m.top.lastFocus = m.tvGuide.lastFocus
 end sub
@@ -981,6 +982,16 @@ function onKeyEvent(key as string, press as boolean) as boolean
       return true
     end if
   else if key = "play"
+    ' TV Guide: quickplay the focused channel
+    if isValid(m.tvGuide)
+      m.log.debug("play pressed on TV Guide", "channelFocused", isValid(m.channelFocused))
+      if isValid(m.channelFocused)
+        m.log.debug("quickplay channel", "id", m.channelFocused.id, "type", m.channelFocused.type)
+        m.top.quickPlayNode = m.channelFocused
+        return true
+      end if
+    end if
+
     itemToPlay = getItemFocused()
 
     if isValid(itemToPlay)

--- a/components/ItemGrid/BaseGridView.bs
+++ b/components/ItemGrid/BaseGridView.bs
@@ -742,6 +742,11 @@ sub optionsClosed()
     reload = true
     libraryId = m.top.parentItem.Id
     setLibraryDisplaySetting(libraryId, "filter", m.options.filter)
+
+    ' Propagate filter change to TV Guide if it's active
+    if isValid(m.tvGuide)
+      m.tvGuide.filter = m.filter
+    end if
   end if
 
   if not isValid(m.options.filterOptions)
@@ -797,8 +802,15 @@ sub optionsClosed()
     loadInitialItems()
   end if
 
-  m.itemGrid.setFocus(m.itemGrid.opacity = 1)
-  m.genreList.setFocus(m.genreList.opacity = 1)
+  ' Restore focus to the correct view after options close
+  if isValid(m.tvGuide)
+    if isValid(m.tvGuide.lastFocus)
+      m.tvGuide.lastFocus.setFocus(true)
+    end if
+  else
+    m.itemGrid.setFocus(m.itemGrid.opacity = 1)
+    m.genreList.setFocus(m.genreList.opacity = 1)
+  end if
 end sub
 
 ' ============================================================================
@@ -962,7 +974,12 @@ function onKeyEvent(key as string, press as boolean) as boolean
       ' Rebuild options before showing dialog (to include any dynamically loaded filters)
       SetUpOptions()
 
-      itemSelected = m.selectedFavoriteItem
+      ' Use TV Guide's focused channel when active, otherwise use the grid's focused item
+      if isValid(m.tvGuide) and isValid(m.channelFocused)
+        itemSelected = m.channelFocused
+      else
+        itemSelected = m.selectedFavoriteItem
+      end if
       if isValid(itemSelected)
         m.options.selectedFavoriteItem = itemSelected
       end if

--- a/components/ItemGrid/BaseGridView.bs
+++ b/components/ItemGrid/BaseGridView.bs
@@ -858,6 +858,14 @@ end sub
 
 sub onVoiceFilter()
   if m.voiceBox.text <> ""
+    ' Route voice search to TV Guide when it's active
+    if isValid(m.tvGuide)
+      m.tvGuide.searchTerm = m.voiceBox.text
+      updateTitle()
+      m.tvGuide.lastFocus.setFocus(true)
+      return
+    end if
+
     m.loadedRows = 0
     m.loadedItems = 0
     m.data = CreateObject("roSGNode", "ContentNode")

--- a/components/api/ApiTask.bs
+++ b/components/api/ApiTask.bs
@@ -1,4 +1,5 @@
 import "pkg:/source/api/baseRequest.bs"
+import "pkg:/source/constants/timeouts.bs"
 import "pkg:/source/roku_modules/rr/Requests.brs"
 import "pkg:/source/utils/misc.bs"
 
@@ -46,7 +47,7 @@ function executeRequest(req as object) as object
   end if
 
   ' timeout in request AA is seconds; rr_Requests expects milliseconds
-  timeout = 30000
+  timeout = timeouts.HTTP_MS
   if isValid(req.timeout) then timeout = req.timeout * 1000
 
   args = {

--- a/components/api/SideEffectTask.bs
+++ b/components/api/SideEffectTask.bs
@@ -1,4 +1,5 @@
 import "pkg:/source/api/baseRequest.bs"
+import "pkg:/source/constants/timeouts.bs"
 import "pkg:/source/roku_modules/rr/Requests.brs"
 import "pkg:/source/utils/misc.bs"
 
@@ -22,7 +23,7 @@ sub executeSideEffect()
   end if
 
   ' timeout in request AA is seconds; rr_Requests expects milliseconds
-  timeout = 30000
+  timeout = timeouts.HTTP_MS
   if isValid(req.timeout) then timeout = req.timeout * 1000
 
   args = {

--- a/components/liveTv/LoadChannelsTask.bs
+++ b/components/liveTv/LoadChannelsTask.bs
@@ -2,11 +2,13 @@ import "pkg:/source/api/ApiClient.bs"
 import "pkg:/source/api/apiPool.bs"
 import "pkg:/source/api/image.bs"
 import "pkg:/source/data/JellyfinDataTransformer.bs"
+import "pkg:/source/roku_modules/log/LogMixin.brs"
 import "pkg:/source/translationKeys.bs"
 import "pkg:/source/utils/misc.bs"
 import "pkg:/source/utils/translate.bs"
 
 sub init()
+  m.log = new log.Logger("LoadChannelsTask")
   m.top.functionName = "loadChannels"
 end sub
 
@@ -18,40 +20,82 @@ sub loadChannels()
     sortOrder = "Descending"
   end if
 
-  params = {
-    includeItemTypes: "LiveTvChannel",
-    SortBy: m.top.sortField,
-    SortOrder: sortOrder,
-    recursive: m.top.isRecursive,
-    UserId: m.global.user.id
-  }
+  ' /LiveTv/Channels doesn't support searchTerm — fall back to generic /Items when search is active
+  hasSearch = (m.top.NameStartsWith <> "" or m.top.searchTerm <> "")
 
-  ' Handle special case when getting names starting with numeral
-  if m.top.NameStartsWith <> ""
-    if m.top.NameStartsWith = "#"
-      params.searchterm = "A"
-    else
-      params.searchterm = m.top.nameStartsWith
+  if hasSearch
+    params = {
+      includeItemTypes: "LiveTvChannel",
+      SortBy: m.top.sortField,
+      SortOrder: sortOrder,
+      recursive: m.top.isRecursive,
+      UserId: m.global.user.id,
+      EnableImageTypes: "Primary",
+      ImageTypeLimit: 1,
+      startIndex: m.top.startIndex
+    }
+    if m.top.limit > 0 then params.limit = m.top.limit
+
+    ' Handle special case when getting names starting with numeral
+    if m.top.NameStartsWith <> ""
+      if m.top.NameStartsWith = "#"
+        params.searchterm = "A"
+      else
+        params.searchterm = m.top.nameStartsWith
+      end if
     end if
+
+    ' Append voice search when there is text
+    if m.top.searchTerm <> ""
+      params.searchTerm = m.top.searchTerm
+    end if
+
+    if m.top.filter = "Favorites"
+      params.append({ isFavorite: true })
+    end if
+
+    m.log.info("loadChannels: fetching via /Items (search active)")
+    timer = CreateObject("roTimespan")
+    res = fetchRes(GetApi().BuildGetItemsByQueryRequest(params), "liveTvChannels")
+  else
+    ' Dedicated endpoint — much faster, no unnecessary metadata (Chapters, Trickplay, Backdrop, etc.)
+    ' OSD loads its own metadata via LoadVideoContentTask when a channel is selected.
+    params = {
+      SortBy: m.top.sortField,
+      SortOrder: sortOrder,
+      UserId: m.global.user.id,
+      addCurrentProgram: false,
+      enableImages: true,
+      enableImageTypes: "Primary",
+      imageTypeLimit: 1,
+      enableUserData: true,
+      startIndex: m.top.startIndex
+    }
+    if m.top.limit > 0 then params.limit = m.top.limit
+
+    if m.top.filter = "Favorites"
+      params.append({ isFavorite: true })
+    end if
+
+    m.log.info("loadChannels: fetching via /LiveTv/Channels")
+    timer = CreateObject("roTimespan")
+    res = fetchRes(GetApi().BuildGetLiveTVChannelsRequest(params), "liveTvChannels")
   end if
 
-  ' Append voice search when there is text
-  if m.top.searchTerm <> ""
-    params.searchTerm = m.top.searchTerm
-  end if
+  elapsed = timer.TotalMilliseconds()
+  m.log.info("loadChannels: fetch completed", "elapsed_ms", elapsed, "ok", isValid(res) and res.ok)
 
-  if m.top.filter = "Favorites"
-    params.append({ isFavorite: true })
-  end if
-
-  res = fetchRes(GetApi().BuildGetItemsByQueryRequest(params), "liveTvChannels")
   results = []
 
   if isValid(res) and res.ok and isValid(res.json)
     if not isValid(res.json.TotalRecordCount)
+      m.log.info("loadChannels: no TotalRecordCount in response")
+      m.top.totalRecordCount = 0
       m.top.channels = results
       return
     end if
+
+    m.top.totalRecordCount = res.json.TotalRecordCount
 
     transformer = JellyfinDataTransformer()
     for each item in res.json.Items
@@ -76,5 +120,6 @@ sub loadChannels()
     end for
   end if
 
+  m.log.info("loadChannels: result", "channelCount", results.Count())
   m.top.channels = results
 end sub

--- a/components/liveTv/LoadChannelsTask.bs
+++ b/components/liveTv/LoadChannelsTask.bs
@@ -20,10 +20,12 @@ sub loadChannels()
     sortOrder = "Descending"
   end if
 
-  ' /LiveTv/Channels doesn't support searchTerm — fall back to generic /Items when search is active
-  hasSearch = (m.top.NameStartsWith <> "" or m.top.searchTerm <> "")
+  searchTerm = m.top.searchTerm.trim()
+  hasSearch = searchTerm <> ""
+  hasAlphaFilter = m.top.NameStartsWith <> ""
 
-  if hasSearch
+  if hasAlphaFilter
+    ' /LiveTv/Channels doesn't support NameStartsWith — fall back to /Items for alpha filtering
     params = {
       includeItemTypes: "LiveTvChannel",
       SortBy: m.top.sortField,
@@ -37,24 +39,17 @@ sub loadChannels()
     if m.top.limit > 0 then params.limit = m.top.limit
 
     ' Handle special case when getting names starting with numeral
-    if m.top.NameStartsWith <> ""
-      if m.top.NameStartsWith = "#"
-        params.searchterm = "A"
-      else
-        params.searchterm = m.top.nameStartsWith
-      end if
-    end if
-
-    ' Append voice search when there is text
-    if m.top.searchTerm <> ""
-      params.searchTerm = m.top.searchTerm
+    if m.top.NameStartsWith = "#"
+      params.searchterm = "A"
+    else
+      params.searchterm = m.top.nameStartsWith
     end if
 
     if m.top.filter = "Favorites"
       params.append({ isFavorite: true })
     end if
 
-    m.log.info("loadChannels: fetching via /Items (search active)")
+    m.log.info("loadChannels: fetching via /Items (alpha filter)")
     timer = CreateObject("roTimespan")
     res = fetchRes(GetApi().BuildGetItemsByQueryRequest(params), "liveTvChannels")
   else
@@ -68,16 +63,23 @@ sub loadChannels()
       enableImages: true,
       enableImageTypes: "Primary",
       imageTypeLimit: 1,
-      enableUserData: true,
-      startIndex: m.top.startIndex
+      enableUserData: true
     }
-    if m.top.limit > 0 then params.limit = m.top.limit
+
+    if hasSearch
+      ' Fetch all channels for client-side name filtering (no pagination)
+      m.log.info("loadChannels: fetching all via /LiveTv/Channels (voice search)", "searchTerm", searchTerm)
+    else
+      ' Normal paginated load
+      params.startIndex = m.top.startIndex
+      if m.top.limit > 0 then params.limit = m.top.limit
+      m.log.info("loadChannels: fetching via /LiveTv/Channels")
+    end if
 
     if m.top.filter = "Favorites"
       params.append({ isFavorite: true })
     end if
 
-    m.log.info("loadChannels: fetching via /LiveTv/Channels")
     timer = CreateObject("roTimespan")
     res = fetchRes(GetApi().BuildGetLiveTVChannelsRequest(params), "liveTvChannels")
   end if
@@ -120,6 +122,67 @@ sub loadChannels()
     end for
   end if
 
+  ' Voice search: client-side filter by channel name/number + program name search
+  if hasSearch and results.count() > 0
+    results = filterByVoiceSearch(results, searchTerm, timer)
+  end if
+
   m.log.info("loadChannels: result", "channelCount", results.Count())
   m.top.channels = results
 end sub
+
+' Filters channels by voice search term using two strategies:
+' 1) Client-side match on channel name and channel number
+' 2) Server-side /LiveTv/Programs search to find channels airing matching content
+' Results are merged and deduplicated.
+' @param channels - Array of transformed channel nodes
+' @param searchTerm - Trimmed, non-empty voice search text
+' @param timer - Running roTimespan for elapsed logging
+' @returns Filtered array of channel nodes
+function filterByVoiceSearch(channels as object, searchTerm as string, timer as object) as object
+  lowerSearch = LCase(searchTerm)
+
+  ' Build a lookup of all channels by ID for merging program results
+  channelById = {}
+  for each node in channels
+    channelById[node.id] = node
+  end for
+
+  ' 1) Filter channels by name/number substring match
+  filtered = []
+  matchedIds = {}
+  for each node in channels
+    nameMatch = LCase(node.name).Instr(lowerSearch) >= 0
+    numberMatch = isValidAndNotEmpty(node.channelNumber) and node.channelNumber.Instr(searchTerm) >= 0
+    if nameMatch or numberMatch
+      filtered.push(node)
+      matchedIds[node.id] = true
+    end if
+  end for
+  m.log.info("filterByVoiceSearch: channel name/number matches", "count", filtered.count())
+
+  ' 2) Search programs to find channels airing matching content
+  programParams = {
+    SearchTerm: searchTerm,
+    Limit: 100,
+    UserId: m.global.user.id
+  }
+  programRes = fetchRes(GetApi().BuildGetLiveTVProgramsRequest(programParams), "liveTvPrograms")
+
+  programElapsed = timer.TotalMilliseconds()
+  m.log.info("filterByVoiceSearch: program search completed", "elapsed_ms", programElapsed, "ok", isValid(programRes) and programRes.ok)
+
+  if isValid(programRes) and programRes.ok and isValid(programRes.json) and isValid(programRes.json.Items)
+    for each program in programRes.json.Items
+      channelId = program.ChannelId ?? ""
+      if channelId <> "" and not matchedIds.DoesExist(channelId) and channelById.DoesExist(channelId)
+        filtered.push(channelById[channelId])
+        matchedIds[channelId] = true
+      end if
+    end for
+    m.log.info("filterByVoiceSearch: total after program merge", "count", filtered.count())
+  end if
+
+  m.top.totalRecordCount = filtered.count()
+  return filtered
+end function

--- a/components/liveTv/LoadChannelsTask.xml
+++ b/components/liveTv/LoadChannelsTask.xml
@@ -12,5 +12,6 @@
     <field id="isRecursive" type="boolean" value="true" />
     <!-- Total records available from server-->
     <field id="channels" type="array" />
+    <field id="totalRecordCount" type="integer" value="0" />
   </interface>
 </component>

--- a/components/liveTv/LoadSheduleTask.bs
+++ b/components/liveTv/LoadSheduleTask.bs
@@ -1,10 +1,12 @@
 import "pkg:/source/api/ApiClient.bs"
 import "pkg:/source/api/apiPool.bs"
 import "pkg:/source/data/JellyfinDataTransformer.bs"
+import "pkg:/source/roku_modules/log/LogMixin.brs"
 import "pkg:/source/translationKeys.bs"
 import "pkg:/source/utils/misc.bs"
 
 sub init()
+  m.log = new log.Logger("LoadScheduleTask")
   m.top.functionName = "loadSchedule"
 end sub
 
@@ -21,7 +23,12 @@ sub loadSchedule()
     MinEndDate: m.top.startTime
   }
 
+  m.log.info("loadSchedule: starting fetch", "startTime", m.top.startTime, "endTime", m.top.endTime)
+  timer = CreateObject("roTimespan")
   res = fetchRes(GetApi().BuildGetLiveTvScheduleRequest(params), "liveTvSchedule")
+  elapsed = timer.TotalMilliseconds()
+  m.log.info("loadSchedule: fetch completed", "elapsed_ms", elapsed, "ok", isValid(res) and res.ok)
+
   results = []
 
   if isValid(res) and res.ok and isValid(res.json)
@@ -38,5 +45,6 @@ sub loadSchedule()
     end for
   end if
 
+  m.log.info("loadSchedule: result", "programCount", results.Count())
   m.top.schedule = results
 end sub

--- a/components/liveTv/schedule.bs
+++ b/components/liveTv/schedule.bs
@@ -27,7 +27,6 @@ sub init()
 
   m.LoadChannelsTask = createObject("roSGNode", "LoadChannelsTask")
   m.LoadChannelsTask.observeField("channels", "onChannelsLoaded")
-  m.LoadChannelsTask.control = "RUN"
 
   m.top.lastFocus = m.scheduleGrid
 
@@ -35,6 +34,21 @@ sub init()
   ' Track which program IDs have been fully loaded to avoid redundant API requests.
   ' Used instead of a .fullyLoaded field on the (immutable) JellyfinBaseItem node.
   m.fullyLoadedProgramIds = {}
+end sub
+
+' Called by BaseGridView after setting filter/searchTerm to avoid double-fire.
+' Applies current filter and search state to the task before starting it.
+' Loads channels in pages of m.channelPageSize for fast initial display.
+sub startLoading()
+  m.channelPageSize = 25
+  m.pendingScheduleIds = []
+
+  m.LoadChannelsTask.filter = m.top.filter
+  m.LoadChannelsTask.searchTerm = m.top.searchTerm
+  m.LoadChannelsTask.limit = m.channelPageSize
+  m.LoadChannelsTask.startIndex = 0
+  startLoadingSpinner()
+  m.LoadChannelsTask.control = "RUN"
 end sub
 
 sub OnScreenShown()
@@ -50,6 +64,11 @@ sub channelFilterSet()
   m.scheduleGrid.jumpToChannel = 0
   if isValid(m.top.filter) and m.LoadChannelsTask.filter <> m.top.filter
     if m.LoadChannelsTask.state = "run" then m.LoadChannelsTask.control = "stop"
+
+    ' Reset pagination and schedule queue for fresh filter
+    m.LoadChannelsTask.startIndex = 0
+    m.channelIndex = {}
+    m.pendingScheduleIds = []
 
     m.LoadChannelsTask.filter = m.top.filter
     m.LoadChannelsTask.control = "RUN"
@@ -70,6 +89,11 @@ sub channelsearchTermSet()
   else if isValid(m.top.searchTerm) and LCase(m.LoadChannelsTask.searchTerm) <> LCase(m.top.searchTerm)
     if m.LoadChannelsTask.state = "run" then m.LoadChannelsTask.control = "stop"
 
+    ' Reset pagination and schedule queue for fresh search
+    m.LoadChannelsTask.startIndex = 0
+    m.channelIndex = {}
+    m.pendingScheduleIds = []
+
     m.LoadChannelsTask.searchTerm = m.top.searchTerm
     startLoadingSpinner()
     m.LoadChannelsTask.control = "RUN"
@@ -77,47 +101,85 @@ sub channelsearchTermSet()
 
 end sub
 
-' Initial list of channels loaded
+' Channels loaded callback — handles both first and subsequent pages.
+' First page: creates grid content, shows channels immediately.
+' Subsequent pages: appends channels to existing grid.
+' Each page queues its channel IDs for schedule loading.
 sub onChannelsLoaded()
-  gridData = createObject("roSGNode", "ContentNode")
+  channels = m.LoadChannelsTask.channels
+  m.log.info("onChannelsLoaded", "channelCount", channels.count(), "startIndex", m.LoadChannelsTask.startIndex, "totalRecordCount", m.LoadChannelsTask.totalRecordCount)
 
-  counter = 0
+  if channels.count() = 0 then return
+
+  isFirstPage = not isValid(m.scheduleGrid.content) or m.scheduleGrid.content.getChildCount() = 0
   channelIdList = ""
 
-  'if search returns channels
-  if m.LoadChannelsTask.channels.count() > 0
-    for each item in m.LoadChannelsTask.channels
+  if isFirstPage
+    ' First page: create fresh grid content
+    gridData = createObject("roSGNode", "ContentNode")
+    for each item in channels
       gridData.appendChild(item)
-      m.channelIndex[item.id] = counter
-      counter = counter + 1
-      channelIdList = channelIdList + item.id + ","
+      m.channelIndex[item.id] = m.channelIndex.count()
+      channelIdList += item.id + ","
     end for
     m.scheduleGrid.content = gridData
 
+    ' Show channels immediately — programs populate as schedule batches arrive
+    m.scheduleGrid.showLoadingDataFeedback = false
+    stopLoadingSpinner()
+
+    ' Create task instances (only once)
     m.LoadScheduleTask = createObject("roSGNode", "LoadScheduleTask")
     m.LoadScheduleTask.observeField("schedule", "onScheduleLoaded")
-
-    m.LoadScheduleTask.startTime = m.gridStartDate.ToISOString()
-    m.LoadScheduleTask.endTime = m.gridEndDate.ToISOString()
-    m.LoadScheduleTask.channelIds = channelIdList
-    m.LoadScheduleTask.control = "RUN"
-
     m.LoadProgramDetailsTask = createObject("roSGNode", "LoadProgramDetailsTask")
     m.LoadProgramDetailsTask.observeField("programDetails", "onProgramDetailsLoaded")
 
     m.scheduleGrid.setFocus(true)
     if m.EPGLaunchCompleteSignaled = false
-      m.top.signalBeacon("EPGLaunchComplete") ' Required Roku Performance monitoring
+      m.top.signalBeacon("EPGLaunchComplete")
       m.EPGLaunchCompleteSignaled = true
     end if
-    m.LoadChannelsTask.channels = []
-
+  else
+    ' Subsequent page: append to existing grid content
+    for each item in channels
+      m.scheduleGrid.content.appendChild(item)
+      m.channelIndex[item.id] = m.channelIndex.count()
+      channelIdList += item.id + ","
+    end for
   end if
 
+  m.LoadChannelsTask.channels = []
+
+  ' Queue schedule load for this batch of channels
+  m.pendingScheduleIds.push(channelIdList)
+  tryLoadNextScheduleBatch()
+
+  ' Load next page of channels if more exist
+  loadedSoFar = m.LoadChannelsTask.startIndex + channels.count()
+  if loadedSoFar < m.LoadChannelsTask.totalRecordCount
+    m.LoadChannelsTask.startIndex = loadedSoFar
+    m.LoadChannelsTask.control = "RUN"
+  end if
+end sub
+
+' Starts the next queued schedule batch if LoadScheduleTask is free.
+sub tryLoadNextScheduleBatch()
+  if not isValid(m.LoadScheduleTask) then return
+  if m.LoadScheduleTask.state = "run" then return
+  if m.pendingScheduleIds.count() = 0 then return
+
+  channelIds = m.pendingScheduleIds[0]
+  m.pendingScheduleIds.delete(0)
+
+  m.LoadScheduleTask.startTime = m.gridStartDate.ToISOString()
+  m.LoadScheduleTask.endTime = m.gridEndDate.ToISOString()
+  m.LoadScheduleTask.channelIds = channelIds
+  m.LoadScheduleTask.control = "RUN"
 end sub
 
 ' When LoadScheduleTask completes (initial or more data) and we have a schedule to display
 sub onScheduleLoaded()
+  m.log.info("onScheduleLoaded", "programCount", m.LoadScheduleTask.schedule.Count())
 
   ' make sure we actually have a schedule (i.e. filter by favorites, but no channels have been favorited)
   if m.scheduleGrid.content.GetChildCount() <= 0
@@ -125,16 +187,18 @@ sub onScheduleLoaded()
   end if
 
   for each item in m.LoadScheduleTask.schedule
-
-    channel = m.scheduleGrid.content.GetChild(m.channelIndex[item.channelId])
-
-    channel.appendChild(item)
+    if isValid(m.channelIndex[item.channelId])
+      channel = m.scheduleGrid.content.GetChild(m.channelIndex[item.channelId])
+      channel.appendChild(item)
+    end if
   end for
 
   m.scheduleGrid.showLoadingDataFeedback = false
   m.scheduleGrid.setFocus(true)
   m.LoadScheduleTask.schedule = []
-  stopLoadingSpinner()
+
+  ' Process next queued schedule batch
+  tryLoadNextScheduleBatch()
 end sub
 
 sub onProgramFocused()
@@ -242,10 +306,16 @@ sub onGridScrolled()
   if m.scheduleGrid.leftEdgeTargetTime + (12 * 60 * 60) > m.gridEndDate.AsSeconds()
 
     ' Ensure the task is not already (still) running,
-    if m.LoadScheduleTask.state <> "run"
+    if isValid(m.LoadScheduleTask) and m.LoadScheduleTask.state <> "run"
+      ' Build channel ID list from ALL loaded channels (not just last batch)
+      allChannelIds = ""
+      for each key in m.channelIndex
+        allChannelIds += key + ","
+      end for
       m.LoadScheduleTask.startTime = m.gridEndDate.ToISOString()
       m.gridEndDate.FromSeconds(m.gridEndDate.AsSeconds() + (24 * 60 * 60))
       m.LoadScheduleTask.endTime = m.gridEndDate.ToISOString()
+      m.LoadScheduleTask.channelIds = allChannelIds
       m.LoadScheduleTask.control = "RUN"
     end if
   end if
@@ -363,4 +433,5 @@ sub destroy()
   ' Clear data structures
   m.channelIndex = invalid
   m.fullyLoadedProgramIds = invalid
+  m.pendingScheduleIds = invalid
 end sub

--- a/components/liveTv/schedule.bs
+++ b/components/liveTv/schedule.bs
@@ -34,6 +34,9 @@ sub init()
   ' Track which program IDs have been fully loaded to avoid redundant API requests.
   ' Used instead of a .fullyLoaded field on the (immutable) JellyfinBaseItem node.
   m.fullyLoadedProgramIds = {}
+
+  ' Guard: onChange handlers must not start tasks before startLoading() configures paging
+  m.loadingInitialized = false
 end sub
 
 ' Called by BaseGridView after setting filter/searchTerm to avoid double-fire.
@@ -47,6 +50,7 @@ sub startLoading()
   m.LoadChannelsTask.searchTerm = m.top.searchTerm
   m.LoadChannelsTask.limit = m.channelPageSize
   m.LoadChannelsTask.startIndex = 0
+  m.loadingInitialized = true
   startLoadingSpinner()
   m.LoadChannelsTask.control = "RUN"
 end sub
@@ -61,44 +65,60 @@ sub OnScreenShown()
 end sub
 
 sub channelFilterSet()
+  ' Don't start tasks before startLoading() has configured paging fields
+  if not m.loadingInitialized then return
+
   m.scheduleGrid.jumpToChannel = 0
   if isValid(m.top.filter) and m.LoadChannelsTask.filter <> m.top.filter
     if m.LoadChannelsTask.state = "run" then m.LoadChannelsTask.control = "stop"
 
-    ' Reset pagination and schedule queue for fresh filter
+    ' Reset all state for fresh filter
     m.LoadChannelsTask.startIndex = 0
     m.channelIndex = {}
+    m.fullyLoadedProgramIds = {}
     m.pendingScheduleIds = []
+    m.scheduleGrid.content = createObject("roSGNode", "ContentNode")
 
     m.LoadChannelsTask.filter = m.top.filter
+    startLoadingSpinner()
     m.LoadChannelsTask.control = "RUN"
   end if
-
 end sub
 
 'Voice Search set
 sub channelsearchTermSet()
+  ' Don't start tasks before startLoading() has configured paging fields
+  if not m.loadingInitialized then return
+
   m.scheduleGrid.jumpToChannel = 0
   'Reset filter if user says all
   if LCase(m.top.searchTerm) = LCase(translate(translationKeys.LabelAll)) or m.LoadChannelsTask.searchTerm = LCase(translate(translationKeys.LabelAll))
     m.top.searchTerm = " "
     m.LoadChannelsTask.searchTerm = " "
+
+    ' Reset all state for fresh search
+    m.channelIndex = {}
+    m.fullyLoadedProgramIds = {}
+    m.pendingScheduleIds = []
+    m.scheduleGrid.content = createObject("roSGNode", "ContentNode")
+
     startLoadingSpinner()
     m.LoadChannelsTask.control = "RUN"
     'filter if the searterm is not invalid
   else if isValid(m.top.searchTerm) and LCase(m.LoadChannelsTask.searchTerm) <> LCase(m.top.searchTerm)
     if m.LoadChannelsTask.state = "run" then m.LoadChannelsTask.control = "stop"
 
-    ' Reset pagination and schedule queue for fresh search
+    ' Reset all state for fresh search
     m.LoadChannelsTask.startIndex = 0
     m.channelIndex = {}
+    m.fullyLoadedProgramIds = {}
     m.pendingScheduleIds = []
+    m.scheduleGrid.content = createObject("roSGNode", "ContentNode")
 
     m.LoadChannelsTask.searchTerm = m.top.searchTerm
     startLoadingSpinner()
     m.LoadChannelsTask.control = "RUN"
   end if
-
 end sub
 
 ' Channels loaded callback — handles both first and subsequent pages.
@@ -109,7 +129,12 @@ sub onChannelsLoaded()
   channels = m.LoadChannelsTask.channels
   m.log.info("onChannelsLoaded", "channelCount", channels.count(), "startIndex", m.LoadChannelsTask.startIndex, "totalRecordCount", m.LoadChannelsTask.totalRecordCount)
 
-  if channels.count() = 0 then return
+  if channels.count() = 0
+    ' No channels returned — stop spinner and show empty grid (e.g. Favorites with none set)
+    stopLoadingSpinner()
+    m.scheduleGrid.showLoadingDataFeedback = false
+    return
+  end if
 
   isFirstPage = not isValid(m.scheduleGrid.content) or m.scheduleGrid.content.getChildCount() = 0
   channelIdList = ""
@@ -434,4 +459,5 @@ sub destroy()
   m.channelIndex = invalid
   m.fullyLoadedProgramIds = invalid
   m.pendingScheduleIds = invalid
+  m.loadingInitialized = false
 end sub

--- a/components/liveTv/schedule.bs
+++ b/components/liveTv/schedule.bs
@@ -97,8 +97,8 @@ sub channelsearchTermSet()
   m.scheduleGrid.jumpToChannel = 0
   'Reset filter if user says all
   if LCase(m.top.searchTerm) = LCase(translate(translationKeys.LabelAll)) or m.LoadChannelsTask.searchTerm = LCase(translate(translationKeys.LabelAll))
-    m.top.searchTerm = " "
-    m.LoadChannelsTask.searchTerm = " "
+    m.top.searchTerm = ""
+    m.LoadChannelsTask.searchTerm = ""
 
     ' Stop in-flight schedule/program tasks — their data belongs to the old search
     if isValid(m.LoadScheduleTask) and m.LoadScheduleTask.state = "run" then m.LoadScheduleTask.control = "stop"

--- a/components/liveTv/schedule.bs
+++ b/components/liveTv/schedule.bs
@@ -143,9 +143,10 @@ sub onChannelsLoaded()
   m.log.info("onChannelsLoaded", "channelCount", channels.count(), "startIndex", m.LoadChannelsTask.startIndex, "totalRecordCount", m.LoadChannelsTask.totalRecordCount)
 
   if channels.count() = 0
-    ' No channels returned — stop spinner and show empty grid (e.g. Favorites with none set)
+    ' No channels returned — stop spinner and restore focus so user can navigate back
     stopLoadingSpinner()
     m.scheduleGrid.showLoadingDataFeedback = false
+    m.scheduleGrid.setFocus(true)
     return
   end if
 
@@ -187,8 +188,6 @@ sub onChannelsLoaded()
       channelIdList += item.id + ","
     end for
   end if
-
-  m.LoadChannelsTask.channels = []
 
   ' Queue schedule load for this batch of channels
   m.pendingScheduleIds.push(channelIdList)

--- a/components/liveTv/schedule.bs
+++ b/components/liveTv/schedule.bs
@@ -72,6 +72,10 @@ sub channelFilterSet()
   if isValid(m.top.filter) and m.LoadChannelsTask.filter <> m.top.filter
     if m.LoadChannelsTask.state = "run" then m.LoadChannelsTask.control = "stop"
 
+    ' Stop in-flight schedule/program tasks — their data belongs to the old filter
+    if isValid(m.LoadScheduleTask) and m.LoadScheduleTask.state = "run" then m.LoadScheduleTask.control = "stop"
+    if isValid(m.LoadProgramDetailsTask) and m.LoadProgramDetailsTask.state = "run" then m.LoadProgramDetailsTask.control = "stop"
+
     ' Reset all state for fresh filter
     m.LoadChannelsTask.startIndex = 0
     m.channelIndex = {}
@@ -96,7 +100,12 @@ sub channelsearchTermSet()
     m.top.searchTerm = " "
     m.LoadChannelsTask.searchTerm = " "
 
+    ' Stop in-flight schedule/program tasks — their data belongs to the old search
+    if isValid(m.LoadScheduleTask) and m.LoadScheduleTask.state = "run" then m.LoadScheduleTask.control = "stop"
+    if isValid(m.LoadProgramDetailsTask) and m.LoadProgramDetailsTask.state = "run" then m.LoadProgramDetailsTask.control = "stop"
+
     ' Reset all state for fresh search
+    m.LoadChannelsTask.startIndex = 0
     m.channelIndex = {}
     m.fullyLoadedProgramIds = {}
     m.pendingScheduleIds = []
@@ -107,6 +116,10 @@ sub channelsearchTermSet()
     'filter if the searterm is not invalid
   else if isValid(m.top.searchTerm) and LCase(m.LoadChannelsTask.searchTerm) <> LCase(m.top.searchTerm)
     if m.LoadChannelsTask.state = "run" then m.LoadChannelsTask.control = "stop"
+
+    ' Stop in-flight schedule/program tasks — their data belongs to the old search
+    if isValid(m.LoadScheduleTask) and m.LoadScheduleTask.state = "run" then m.LoadScheduleTask.control = "stop"
+    if isValid(m.LoadProgramDetailsTask) and m.LoadProgramDetailsTask.state = "run" then m.LoadProgramDetailsTask.control = "stop"
 
     ' Reset all state for fresh search
     m.LoadChannelsTask.startIndex = 0
@@ -153,11 +166,13 @@ sub onChannelsLoaded()
     m.scheduleGrid.showLoadingDataFeedback = false
     stopLoadingSpinner()
 
-    ' Create task instances (only once)
-    m.LoadScheduleTask = createObject("roSGNode", "LoadScheduleTask")
-    m.LoadScheduleTask.observeField("schedule", "onScheduleLoaded")
-    m.LoadProgramDetailsTask = createObject("roSGNode", "LoadProgramDetailsTask")
-    m.LoadProgramDetailsTask.observeField("programDetails", "onProgramDetailsLoaded")
+    ' Create task instances only once — filter/search resets reuse them
+    if not isValid(m.LoadScheduleTask)
+      m.LoadScheduleTask = createObject("roSGNode", "LoadScheduleTask")
+      m.LoadScheduleTask.observeField("schedule", "onScheduleLoaded")
+      m.LoadProgramDetailsTask = createObject("roSGNode", "LoadProgramDetailsTask")
+      m.LoadProgramDetailsTask.observeField("programDetails", "onProgramDetailsLoaded")
+    end if
 
     m.scheduleGrid.setFocus(true)
     if m.EPGLaunchCompleteSignaled = false

--- a/components/liveTv/schedule.xml
+++ b/components/liveTv/schedule.xml
@@ -16,5 +16,6 @@
     <field id="focusedChannel" type="node" alwaysNotify="false" />
     <field id="filter" type="string" value="All" onChange="channelFilterSet" />
     <field id="searchTerm" type="string" value="" onChange="channelsearchTermSet" />
+    <function name="startLoading" />
   </interface>
 </component>

--- a/components/video/TrickplayTileLoader.bs
+++ b/components/video/TrickplayTileLoader.bs
@@ -1,4 +1,5 @@
 import "pkg:/source/api/baseRequest.bs"
+import "pkg:/source/constants/timeouts.bs"
 import "pkg:/source/roku_modules/log/LogMixin.brs"
 import "pkg:/source/utils/misc.bs"
 import "pkg:/source/utils/trickplay.bs"
@@ -96,7 +97,7 @@ function downloadTile(tileIndex as integer, cachePath as string) as boolean
   end if
 
   ' Wait for response
-  resp = wait(30000, port)
+  resp = wait(timeouts.HTTP_MS, port)
 
   ' Check for timeout (resp = invalid)
   if resp = invalid

--- a/source/api/apiPool.bs
+++ b/source/api/apiPool.bs
@@ -1,3 +1,4 @@
+import "pkg:/source/constants/timeouts.bs"
 import "pkg:/source/utils/misc.bs"
 
 ' Submits a request to the API queue coordinator and blocks the calling Task thread
@@ -15,7 +16,7 @@ import "pkg:/source/utils/misc.bs"
 '
 ' @param req      - request AA from a Build*Request() method; returns invalid if invalid
 ' @param requestId - unique string identifying this request (echoed in the response AA)
-' @return response AA { requestId, ok, statusCode, json, text } or invalid on timeout
+' @return response AA { requestId, ok, statusCode, json, text } or invalid on timeout (timeouts.API_WAIT_MS)
 function fetchRes(req as dynamic, requestId as string) as dynamic
   if not isValid(req) then return invalid
 
@@ -64,7 +65,7 @@ function fetchRes(req as dynamic, requestId as string) as dynamic
   ' Wake-up signal — coordinator ignores the value and reads children instead.
   apiQueue.enqueue = requestId
 
-  msg = wait(30000, port)
+  msg = wait(timeouts.API_WAIT_MS, port)
   if type(msg) = "roSGNodeEvent"
     resultNode.unobserveField("isDone")
     return resultNode.result

--- a/source/api/baseRequest.bs
+++ b/source/api/baseRequest.bs
@@ -78,11 +78,19 @@ function getJson(req)
   ' Handle case where server URL is not set or invalid
   if not isValid(req) then return invalid
 
-  'req.retainBodyOnError(True)
-  data = req.GetToString()
-  if not isValid(data) or data = ""
+  req.setMessagePort(CreateObject("roMessagePort"))
+  req.AsyncGetToString()
+  resp = wait(timeouts.HTTP_MS, req.GetMessagePort())
+  if type(resp) <> "roUrlEvent"
+    req.AsyncCancel()
     return invalid
   end if
+
+  data = resp.GetString()
+  if data = ""
+    return invalid
+  end if
+
   json = ParseJson(data)
   return json
 end function
@@ -96,6 +104,7 @@ function postJson(req, data = "" as string)
   req.AsyncPostFromString(data)
   resp = wait(timeouts.HTTP_MS, req.GetMessagePort())
   if type(resp) <> "roUrlEvent"
+    req.AsyncCancel()
     return invalid
   end if
 

--- a/source/api/baseRequest.bs
+++ b/source/api/baseRequest.bs
@@ -1,3 +1,5 @@
+import "pkg:/source/constants/timeouts.bs"
+
 ' Functions for making requests to the API
 function buildParams(params = {} as object) as string
   ' Take an object of parameters and construct the URL query
@@ -92,7 +94,7 @@ function postJson(req, data = "" as string)
   req.setMessagePort(CreateObject("roMessagePort"))
   req.AddHeader("Content-Type", "application/json")
   req.AsyncPostFromString(data)
-  resp = wait(30000, req.GetMessagePort())
+  resp = wait(timeouts.HTTP_MS, req.GetMessagePort())
   if type(resp) <> "roUrlEvent"
     return invalid
   end if

--- a/source/api/items.bs
+++ b/source/api/items.bs
@@ -1,5 +1,6 @@
 import "pkg:/source/api/ApiClient.bs"
 import "pkg:/source/api/image.bs"
+import "pkg:/source/constants/timeouts.bs"
 import "pkg:/source/data/JellyfinDataTransformer.bs"
 import "pkg:/source/enums/SubtitleSelection.bs"
 import "pkg:/source/utils/deviceCapabilities.bs"
@@ -240,8 +241,8 @@ function searchMedia(query as string) as object
   searchTask.query = query
   searchTask.control = "RUN"
 
-  ' Block until SearchTask completes (30s timeout matches fetchRes)
-  msg = wait(30000, port)
+  ' Block until SearchTask completes (timeouts.HTTP_MS)
+  msg = wait(timeouts.HTTP_MS, port)
   searchTask.unobserveField("results")
   searchTask.control = "STOP"
 

--- a/source/constants/timeouts.bs
+++ b/source/constants/timeouts.bs
@@ -1,0 +1,20 @@
+' @fileoverview Centralized timeout constants for API requests and task coordination.
+' All values in milliseconds.
+
+namespace timeouts
+
+  ' Default HTTP request timeout passed to roku-requests.
+  ' Used by ApiTask and SideEffectTask for all API pool requests.
+  const HTTP_MS = 10000
+
+  ' API pool caller wait (fetchRes).
+  ' 2s buffer above HTTP_MS so the HTTP layer times out first,
+  ' preventing orphaned pool slots when the wait expires before the HTTP call.
+  const API_WAIT_MS = 12000
+
+  ' Session connection check timeout.
+  ' Intentionally higher to accommodate slow/remote servers
+  ' and redirect chains during initial connection.
+  const CONNECTION_CHECK_MS = 35000
+
+end namespace

--- a/source/utils/session.bs
+++ b/source/utils/session.bs
@@ -165,7 +165,7 @@ namespace server
     if type(resp) <> "roUrlEvent"
       ' Check for timeout (wait() returns invalid after timeout expires)
       if resp = invalid
-        return { "Error": true, "ErrorMessage": "Connection timed out - server did not respond within " + stri(timeouts.CONNECTION_CHECK_MS / 1000).trim() + " seconds" }
+        return { "Error": true, "ErrorMessage": "Connection timed out - server did not respond within " + stri(timeouts.CONNECTION_CHECK_MS \ 1000).trim() + " seconds" }
       end if
 
       ' Handle unexpected message types

--- a/source/utils/session.bs
+++ b/source/utils/session.bs
@@ -3,9 +3,9 @@
 ' Organized via namespaces for clean code organization
 
 import "pkg:/source/api/ApiClient.bs"
-import "pkg:/source/constants/timeouts.bs"
 import "pkg:/source/api/baseRequest.bs"
 import "pkg:/source/api/userAuth.bs"
+import "pkg:/source/constants/timeouts.bs"
 import "pkg:/source/data/SessionDataTransformer.bs"
 import "pkg:/source/migrations.bs"
 import "pkg:/source/utils/globals.bs"

--- a/source/utils/session.bs
+++ b/source/utils/session.bs
@@ -3,6 +3,7 @@
 ' Organized via namespaces for clean code organization
 
 import "pkg:/source/api/ApiClient.bs"
+import "pkg:/source/constants/timeouts.bs"
 import "pkg:/source/api/baseRequest.bs"
 import "pkg:/source/api/userAuth.bs"
 import "pkg:/source/data/SessionDataTransformer.bs"
@@ -157,14 +158,14 @@ namespace server
     req.setMessagePort(CreateObject("roMessagePort"))
     req.AsyncGetToString()
 
-    ' Wait for response (35 second timeout)
-    resp = wait(35000, req.GetMessagePort())
+    ' Wait for response (timeouts.CONNECTION_CHECK_MS)
+    resp = wait(timeouts.CONNECTION_CHECK_MS, req.GetMessagePort())
 
     ' Handle non-roUrlEvent responses (timeouts, system errors, etc.)
     if type(resp) <> "roUrlEvent"
       ' Check for timeout (wait() returns invalid after timeout expires)
       if resp = invalid
-        return { "Error": true, "ErrorMessage": "Connection timed out - server did not respond within 35 seconds" }
+        return { "Error": true, "ErrorMessage": "Connection timed out - server did not respond within " + stri(timeouts.CONNECTION_CHECK_MS / 1000).trim() + " seconds" }
       end if
 
       ' Handle unexpected message types


### PR DESCRIPTION
Centralized API timeouts, major TV Guide performance improvements, and quickplay support on the TV Guide.

## Changes

- Centralize all hardcoded 30s API timeouts into `source/constants/timeouts.bs` namespace and reduce default to 10s
- Switch TV Guide channel loading from generic `/Items` endpoint (with full metadata via `injectDefaults`) to dedicated `/LiveTv/Channels` with `addCurrentProgram=false` and minimal image params
- Paginate channel loading (25 per page) with incremental schedule fetching so the first batch renders immediately
- Fix double-fire bug where `Schedule.init()` auto-started `LoadChannelsTask` before filter/searchTerm were set by `BaseGridView`
- Show channels in the TimeGrid immediately instead of waiting for all programs to load
- Enable quickplay (play button) on the TV Guide using the already-tracked focused channel
- Add roku-log diagnostic timing to `LoadChannelsTask`, `LoadScheduleTask`, and `schedule.bs` for performance monitoring
- Fall back to generic `/Items` endpoint for voice/alpha search since `/LiveTv/Channels` doesn't support `searchTerm`