### PR TITLE
feat: live progress bar on Program cells

### DIFF
--- a/components/extras/ExtrasRowList.bs
+++ b/components/extras/ExtrasRowList.bs
@@ -108,6 +108,13 @@ sub init()
   ' Track the last focused row index so horizontal item scrolling within a row
   ' does not trigger an unnecessary panel position recalculation.
   m.lastFocusedRowIndex = -1
+
+  ' Refetch the Channel Programs row (TvChannel "Up Next" / Program "More on
+  ' this Channel") when the base class's progress tick detects an expired
+  ' broadcast. m.isRefetchingChannelPrograms debounces repeated expiry signals
+  ' while a refetch is already in flight.
+  m.isRefetchingChannelPrograms = false
+  m.top.observeField("programsExpired", "onProgramsExpired")
 end sub
 
 sub updateSize()
@@ -917,6 +924,72 @@ sub onProgramChannelProgramsLoaded()
   m.LikeThisTask.itemId = m.top.parentId
   m.LikeThisTask.observeField("content", "onLikeThisLoaded")
   m.LikeThisTask.control = "RUN"
+end sub
+
+' Fires when JRRowList's progress tick detects at least one expired Program
+' among this list's rows. Triggers a targeted refetch of the Channel Programs
+' row (TvChannel "Up Next" or Program "More on this Channel") so finished
+' broadcasts roll off and new ones take their place.
+'
+' Deliberately does NOT re-chain to LikeThisTask — related content is stable
+' over a viewing session and should not be refetched just because a program
+' expired. m.isRefetchingChannelPrograms debounces repeated expiry signals.
+sub onProgramsExpired()
+  if m.isRefetchingChannelPrograms then return
+  if not isValid(m.rowChannelPrograms) then return
+
+  itemType = m.top.type
+  handlerName = ""
+  channelId = invalid
+
+  if itemType = "TvChannel"
+    handlerName = "onChannelProgramsRefetched"
+    channelId = m.top.parentId
+  else if itemType = "Program"
+    handlerName = "onProgramChannelProgramsRefetched"
+    channelId = m.programChannelId
+  end if
+
+  if handlerName = "" or not isValidAndNotEmpty(channelId) then return
+
+  m.isRefetchingChannelPrograms = true
+  m.LoadChannelProgramsTask.control = "STOP"
+  m.LoadChannelProgramsTask.unobserveField("content")
+  m.LoadChannelProgramsTask.itemId = channelId
+  m.LoadChannelProgramsTask.observeField("content", handlerName)
+  m.LoadChannelProgramsTask.control = "RUN"
+end sub
+
+' Refetch handler for TvChannel "Up Next". Replaces the row content in place
+' without re-chaining to LikeThisTask (unlike the initial-load handler).
+sub onChannelProgramsRefetched()
+  items = m.LoadChannelProgramsTask.content
+  m.LoadChannelProgramsTask.unobserveField("content")
+  m.LoadChannelProgramsTask.content = []
+  m.isRefetchingChannelPrograms = false
+
+  if isValid(items) and items.count() > 0
+    m.rowChannelPrograms = populateRow(m.rowChannelPrograms, translate(translationKeys.LabelUpNext), items, rowSlotSize.ROW_HEIGHT_SQUARE)
+  else if isValid(m.rowChannelPrograms)
+    removeRow(m.rowChannelPrograms)
+    m.rowChannelPrograms = invalid
+  end if
+end sub
+
+' Refetch handler for Program "More on this Channel". Same in-place-update
+' pattern as onChannelProgramsRefetched — no chain to LikeThisTask.
+sub onProgramChannelProgramsRefetched()
+  items = m.LoadChannelProgramsTask.content
+  m.LoadChannelProgramsTask.unobserveField("content")
+  m.LoadChannelProgramsTask.content = []
+  m.isRefetchingChannelPrograms = false
+
+  if isValid(items) and items.count() > 0
+    m.rowChannelPrograms = populateRow(m.rowChannelPrograms, translate(translationKeys.LabelMoreOnThisChannel), items, rowSlotSize.ROW_HEIGHT_SQUARE)
+  else if isValid(m.rowChannelPrograms)
+    removeRow(m.rowChannelPrograms)
+    m.rowChannelPrograms = invalid
+  end if
 end sub
 
 ' populateRow: Reuse an existing row ContentNode (clearing its children) or create a new one.

--- a/components/home/HomeRows.bs
+++ b/components/home/HomeRows.bs
@@ -45,6 +45,11 @@ sub init()
   m.isLoadingResume = false
   m.isLoadingNextUp = false
   m.isLoadingOnNow = false
+
+  ' Refetch the On Now row when the base class's progress tick detects that at
+  ' least one Program has ended. Without this, sitting on Home long enough would
+  ' leave a row of finished broadcasts until the user refreshes manually.
+  m.top.observeField("programsExpired", "onProgramsExpired")
 end sub
 
 ' loadLibraries: Entry point called by Home.bs via callFunc.
@@ -526,6 +531,30 @@ sub updateOnNowItems()
   m.isLoadingOnNow = false
 
   populateRowFromData("livetv", itemData)
+end sub
+
+' Fires when JRRowList's progress tick detects at least one expired Program.
+' Re-runs LoadOnNowTask to pull fresh currently-airing data. The m.isLoadingOnNow
+' guard debounces repeated expiry signals while a load is already in flight, and
+' the "livetv" section plan check avoids wasted requests when the user has
+' disabled the On Now section.
+sub onProgramsExpired()
+  if m.isLoadingOnNow then return
+  if not isValidAndNotEmpty(m.sectionPlan) then return
+
+  hasLiveTv = false
+  for each section in m.sectionPlan
+    if section.type = "livetv"
+      hasLiveTv = true
+      exit for
+    end if
+  end for
+  if not hasLiveTv then return
+
+  m.isLoadingOnNow = true
+  m.LoadOnNowTask.unobserveField("content")
+  m.LoadOnNowTask.observeField("content", "updateOnNowItems")
+  m.LoadOnNowTask.control = "RUN"
 end sub
 
 ' updateLatestItems: Processes LoadItemsTask content for a latest-in-library row.

--- a/components/ui/rowitem/JRRowItem.bs
+++ b/components/ui/rowitem/JRRowItem.bs
@@ -37,6 +37,13 @@ sub init()
   ' this to colorBackgroundPrimary so the white silhouette icon picks up the theme color.
   m.defaultPosterBlendColor = m.poster.blendColor
 
+  ' Reactive bridge for live Program progress bars. When this cell is bound to
+  ' a Program content node, an observer is installed on that node's
+  ' playedPercentage field so JRRowList's 60s tick can refresh the visible
+  ' progress bar without reassigning itemContent (which would re-render the cell).
+  ' See applyPlayedPercentage().
+  m.observedProgramNode = invalid
+
   m.poster.observeField("loadStatus", "onPosterLoadStatusChanged")
   m.itemIcon.observeField("loadStatus", "onIconLoadStatusChanged")
   m.top.observeField("renderTracking", "onRenderTrackingChanged")
@@ -218,7 +225,48 @@ sub renderStandardItem(item as object, slotWidth as float, posterHeight as float
     m.poster.unplayedCount = item.unplayedItemCount
   end if
 
-  m.poster.playedPercentage = item.playedPercentage
+  applyPlayedPercentage(item)
+end sub
+
+' Sets the poster's progress bar percentage based on item type.
+' Programs use live broadcast elapsed time (wall-clock derived); everything
+' else uses UserData.PlayedPercentage as flattened by the data transformer.
+'
+' For Programs, also installs a reactive bridge observer on the content node's
+' playedPercentage field. JRRowList's 60s tick rewrites that field, and this
+' observer forwards the change to m.poster.playedPercentage — updating any
+' currently-mounted VideoProgressBar without a cell re-render.
+sub applyPlayedPercentage(item as object)
+  ' Must run unconditionally before any early return. A recycled cell may be
+  ' switching from Program A to Program B, or from a Program to an Episode —
+  ' leaving the old observer attached would land stale tick writes on the
+  ' wrong poster the next time JRRowList fires.
+  unobserveProgramProgress()
+
+  if item.type = "Program"
+    nowSeconds = CreateObject("roDateTime").AsSeconds()
+    m.poster.playedPercentage = computeProgramBroadcastProgress(item.PlayStart, item.PlayDuration, nowSeconds)
+    item.observeField("playedPercentage", "onProgramProgressChanged")
+    m.observedProgramNode = item
+  else
+    m.poster.playedPercentage = item.playedPercentage
+  end if
+end sub
+
+' Tears down the bridge observer on the previously-bound Program content node.
+' Called unconditionally at the top of applyPlayedPercentage so recycled cells
+' never leak observers onto stale content nodes.
+sub unobserveProgramProgress()
+  if isValid(m.observedProgramNode)
+    m.observedProgramNode.unobserveField("playedPercentage")
+    m.observedProgramNode = invalid
+  end if
+end sub
+
+' Forwarded write from the bound Program content node to the live poster.
+' Fires when JRRowList's tick rewrites the node's playedPercentage.
+sub onProgramProgressChanged(msg as object)
+  m.poster.playedPercentage = msg.getData()
 end sub
 
 ' Updates positions and sizes of all child nodes to match the current slot dimensions.

--- a/components/ui/rowitem/JRRowItem.bs
+++ b/components/ui/rowitem/JRRowItem.bs
@@ -66,6 +66,13 @@ sub renderItem()
   item = m.top.itemContent
   if not isValid(item) then return
 
+  ' Tear down any Program progress observer from the previous render before
+  ' branching into tile/standard/loading modes. Must run unconditionally here
+  ' (not inside applyPlayedPercentage) because the library-tile and loading
+  ' branches never reach applyPlayedPercentage — leaving a stale observer
+  ' attached would land tick writes on the wrong recycled poster.
+  unobserveProgramProgress()
+
   m.poster.callFunc("resetBadge")
   m.isTextureUnloaded = false
 
@@ -236,13 +243,10 @@ end sub
 ' playedPercentage field. JRRowList's 60s tick rewrites that field, and this
 ' observer forwards the change to m.poster.playedPercentage — updating any
 ' currently-mounted VideoProgressBar without a cell re-render.
+'
+' Observer teardown for the previous render happens unconditionally at the
+' top of renderItem(), so this function only needs to install — not clear.
 sub applyPlayedPercentage(item as object)
-  ' Must run unconditionally before any early return. A recycled cell may be
-  ' switching from Program A to Program B, or from a Program to an Episode —
-  ' leaving the old observer attached would land stale tick writes on the
-  ' wrong poster the next time JRRowList fires.
-  unobserveProgramProgress()
-
   if item.type = "Program"
     nowSeconds = CreateObject("roDateTime").AsSeconds()
     m.poster.playedPercentage = computeProgramBroadcastProgress(item.PlayStart, item.PlayDuration, nowSeconds)
@@ -254,8 +258,9 @@ sub applyPlayedPercentage(item as object)
 end sub
 
 ' Tears down the bridge observer on the previously-bound Program content node.
-' Called unconditionally at the top of applyPlayedPercentage so recycled cells
-' never leak observers onto stale content nodes.
+' Called unconditionally at the top of renderItem() so recycled cells never
+' leak observers onto stale content nodes — regardless of which render branch
+' (Loading skeleton, library tile, standard item) the cell takes next.
 sub unobserveProgramProgress()
   if isValid(m.observedProgramNode)
     m.observedProgramNode.unobserveField("playedPercentage")

--- a/components/ui/rowitem/JRRowItem.bs
+++ b/components/ui/rowitem/JRRowItem.bs
@@ -50,7 +50,16 @@ sub init()
 end sub
 
 sub onItemContentChanged()
-  if not isValid(m.top.itemContent) then return
+  ' Tear down any Program progress observer from a prior bind even when the
+  ' new itemContent is invalid. renderItem()'s top-of-function teardown only
+  ' covers transitions through a valid bind; transitions to invalid never
+  ' reach renderItem() and would otherwise leak the observer onto a stale
+  ' content node — bounded by the next valid rebind, or unbounded if the cell
+  ' is destroyed (Roku exposes no destroy lifecycle hook to clean up later).
+  if not isValid(m.top.itemContent)
+    unobserveProgramProgress()
+    return
+  end if
   if m.top.width <= 0 or m.top.height <= 0 then return
   setupTextureObserver()
   renderItem()
@@ -244,8 +253,15 @@ end sub
 ' observer forwards the change to m.poster.playedPercentage — updating any
 ' currently-mounted VideoProgressBar without a cell re-render.
 '
-' Observer teardown for the previous render happens unconditionally at the
-' top of renderItem(), so this function only needs to install — not clear.
+' Observer teardown is split across two sites to cover every itemContent
+' transition this cell can see:
+'   • renderItem() top — handles transitions into a new valid bind (recycle
+'     into a different content node) and re-renders triggered by size changes
+'     on the same item. Required so applyPlayedPercentage doesn't double-
+'     install observers on size-change re-renders.
+'   • onItemContentChanged() invalid path — handles transitions to invalid,
+'     which never reach renderItem() and would otherwise leak the observer.
+' This function therefore only needs to install — not clear.
 sub applyPlayedPercentage(item as object)
   if item.type = "Program"
     nowSeconds = CreateObject("roDateTime").AsSeconds()
@@ -258,9 +274,15 @@ sub applyPlayedPercentage(item as object)
 end sub
 
 ' Tears down the bridge observer on the previously-bound Program content node.
-' Called unconditionally at the top of renderItem() so recycled cells never
-' leak observers onto stale content nodes — regardless of which render branch
-' (Loading skeleton, library tile, standard item) the cell takes next.
+' Called from two sites to cover every itemContent transition this cell sees:
+'   • Top of renderItem() — runs before tile/standard/loading branching so
+'     recycled cells never leak observers onto stale content nodes regardless
+'     of which render branch the new bind takes. Also covers size-change re-
+'     renders on the same item (without it, applyPlayedPercentage would stack
+'     duplicate observers on every size change).
+'   • Invalid path of onItemContentChanged() — covers transitions to invalid,
+'     which never reach renderItem(). Without this site, an observer installed
+'     on a Program node would leak when the cell unbinds.
 sub unobserveProgramProgress()
   if isValid(m.observedProgramNode)
     m.observedProgramNode.unobserveField("playedPercentage")

--- a/components/ui/rowlist/JRRowList.bs
+++ b/components/ui/rowlist/JRRowList.bs
@@ -24,6 +24,143 @@ sub init()
     applyFallbackFontScale()
   end if
 
+  ' ── Program progress bar tick ───────────────────────────────────────────
+  ' JRRowItem (and its BrowseRowItem subclass) draws a progress bar on
+  ' Program cells by reading item.playedPercentage. Live broadcasts advance
+  ' in real time so the percentage must be refreshed periodically. This
+  ' base-class tick propagates the feature to every JRRowList descendant
+  ' (HomeRows, FavoritesRows, SearchRow, ExtrasRowList) with no per-screen
+  ' plumbing — it gates itself on textureManagerState, which every row-list
+  ' screen already sets via activateTextureManager/hideTextureManager.
+  m.programProgressTimer = invalid
+  m.observedContentRoot = invalid
+  m.isProgramProgressTicking = false
+
+  m.top.observeField("content", "onProgramProgressContentChanged")
+end sub
+
+' ============================================
+' PROGRAM PROGRESS BAR TICK
+' ============================================
+
+' Fires when m.top.content is assigned or reassigned by a subclass.
+' Rebinds the textureManagerState observer to the new content root so the
+' tick timer tracks visibility transitions for the current data set.
+sub onProgramProgressContentChanged()
+  if isValid(m.observedContentRoot)
+    m.observedContentRoot.unobserveField("textureManagerState")
+    m.observedContentRoot = invalid
+  end if
+
+  content = m.top.content
+  if not isValid(content) then return
+
+  ' Pre-add textureManagerState so observeField has a real field to attach to.
+  ' Subclasses assign m.top.content BEFORE calling initTextureManager, which
+  ' means the field would not yet exist at the time this handler runs and the
+  ' observer would silently fail to attach. textureManager.bs handles the
+  ' pre-added-field case via a hasField check, so both call sites coexist.
+  if not content.hasField("textureManagerState")
+    content.addField("textureManagerState", "string", false)
+  end if
+
+  m.observedContentRoot = content
+  content.observeField("textureManagerState", "onProgramProgressVisibilityChanged")
+  ' Honour the current state immediately — content may already be "active"
+  ' by the time we subscribe (e.g. reassignment after a refresh).
+  syncProgramProgressTicking(content.textureManagerState)
+end sub
+
+sub onProgramProgressVisibilityChanged(msg as object)
+  syncProgramProgressTicking(msg.getData())
+end sub
+
+' Starts or stops the 60s Program progress tick based on the visibility state
+' broadcast by the texture manager. Idempotent; safe on every state change.
+' State arrives as dynamic because textureManagerState is unset (invalid) on
+' freshly-created content roots — setupTextureManager only assigns "init"
+' after the subclass first populates the content tree.
+sub syncProgramProgressTicking(state as dynamic)
+  isString = isValid(state) and (type(state) = "roString" or type(state) = "String")
+
+  if isString and state = "active"
+    startProgramProgressTicking()
+  else
+    ' Any non-"active" value (invalid, "init", "hidden", "destroyed") stops
+    ' ticking. On "destroyed" we also release the Timer node so the screen
+    ' tears down cleanly.
+    stopProgramProgressTicking(isString and state = "destroyed")
+  end if
+end sub
+
+sub startProgramProgressTicking()
+  if m.isProgramProgressTicking then return
+
+  if not isValid(m.programProgressTimer)
+    m.programProgressTimer = CreateObject("roSGNode", "Timer")
+    m.programProgressTimer.duration = 60
+    m.programProgressTimer.repeat = true
+    m.top.appendChild(m.programProgressTimer)
+  end if
+
+  m.programProgressTimer.observeField("fire", "onProgramProgressTick")
+  m.programProgressTimer.control = "start"
+  m.isProgramProgressTicking = true
+
+  ' Immediate refresh so returning from Settings/another screen does not
+  ' leave stale percentages on screen for up to 60 seconds.
+  onProgramProgressTick()
+end sub
+
+sub stopProgramProgressTicking(releaseTimer = false as boolean)
+  if isValid(m.programProgressTimer)
+    m.programProgressTimer.control = "stop"
+    m.programProgressTimer.unobserveField("fire")
+    if releaseTimer
+      m.top.removeChild(m.programProgressTimer)
+      m.programProgressTimer = invalid
+    end if
+  end if
+  m.isProgramProgressTicking = false
+end sub
+
+' Walks every row and rewrites playedPercentage on every Program child to its
+' current broadcast-elapsed percentage. JRRowItem's bridge observer forwards
+' these writes to any currently-mounted poster cells, refreshing visible bars
+' without triggering a cell re-render. Non-Program items are skipped.
+'
+' Also detects expired broadcasts (now >= PlayStart + PlayDuration) and raises
+' the programsExpired field. Subclasses that can refetch (HomeRows, ExtrasRowList)
+' observe that field and trigger a fresh load, so sitting on a screen for long
+' enough doesn't leave an empty row of finished programs.
+sub onProgramProgressTick()
+  content = m.top.content
+  if not isValid(content) then return
+
+  nowSeconds = CreateObject("roDateTime").AsSeconds()
+  hasExpiredProgram = false
+
+  for i = 0 to content.getChildCount() - 1
+    row = content.getChild(i)
+    if isValid(row)
+      for j = 0 to row.getChildCount() - 1
+        item = row.getChild(j)
+        if isValid(item) and item.type = "Program"
+          item.playedPercentage = computeProgramBroadcastProgress(item.PlayStart, item.PlayDuration, nowSeconds)
+          ' Expiry check uses the same window math as the progress computation.
+          ' PlayStart/PlayDuration default to 0 for items missing broadcast data —
+          ' the > 0 guards prevent those from being flagged as expired.
+          if item.PlayStart > 0 and item.PlayDuration > 0 and nowSeconds >= (item.PlayStart + item.PlayDuration)
+            hasExpiredProgram = true
+          end if
+        end if
+      end for
+    end if
+  end for
+
+  if hasExpiredProgram
+    m.top.programsExpired = true
+  end if
 end sub
 
 function onKeyEvent(key as string, press as boolean) as boolean

--- a/components/ui/rowlist/JRRowList.bs
+++ b/components/ui/rowlist/JRRowList.bs
@@ -124,23 +124,54 @@ sub stopProgramProgressTicking(releaseTimer = false as boolean)
   m.isProgramProgressTicking = false
 end sub
 
-' Walks every row and rewrites playedPercentage on every Program child to its
-' current broadcast-elapsed percentage. JRRowItem's bridge observer forwards
-' these writes to any currently-mounted poster cells, refreshing visible bars
-' without triggering a cell re-render. Non-Program items are skipped.
+' Walks the texture manager's loaded row range and rewrites playedPercentage on
+' every Program child to its current broadcast-elapsed percentage. JRRowItem's
+' bridge observer forwards these writes to any currently-mounted poster cells,
+' refreshing visible bars without triggering a cell re-render. Non-Program
+' items are skipped.
 '
-' Also detects expired broadcasts (now >= PlayStart + PlayDuration) and raises
-' the programsExpired field. Subclasses that can refetch (HomeRows, ExtrasRowList)
-' observe that field and trigger a fresh load, so sitting on a screen for long
-' enough doesn't leave an empty row of finished programs.
+' Iteration is scoped to loadedRowRange [bufferStart..bufferEnd] — the vertical
+' range maintained by textureManager.bs — so large datasets (SearchRow,
+' FavoritesRows) don't pay the cost of walking hundreds of offscreen items
+' every minute on the render thread. Offscreen rows whose percentage goes
+' stale during scroll-away will update at the next tick after re-entering the
+' buffer range (up to ~60s stale window, accepted trade-off).
+'
+' Also detects expired broadcasts (now >= PlayStart + PlayDuration) within the
+' same buffer range and raises the programsExpired field. Subclasses that can
+' refetch (HomeRows, ExtrasRowList) observe that field and trigger a fresh
+' load. Expiry detection is scoped to the buffer range rather than the full
+' content tree because Live TV rows in HomeRows/ExtrasRowList are always in
+' the vertical buffer in practice — full-scan expiry on every tick would be
+' unnecessary work for zero real-world benefit.
+'
+' Hard-guards rather than full-scan fallback when loadedRowRange is missing or
+' invalid: the tick only runs while textureManagerState = "active", which the
+' state machine guarantees implies loadedRowRange is populated. A missing
+' field surfaces an ordering regression loudly rather than masking it.
 sub onProgramProgressTick()
   content = m.top.content
   if not isValid(content) then return
+  if not content.hasField("loadedRowRange") then return
+
+  range = content.loadedRowRange
+  if not isValid(range) or range.count() < 4 then return
+
+  bufferStart = range[0]
+  bufferEnd = range[3]
+
+  ' Sentinel [-1,-1,-1,-1] means no rows are currently managed (empty content
+  ' or no focus). Nothing is mounted, so nothing to update.
+  if bufferStart < 0 or bufferEnd < 0 then return
+
+  totalRows = content.getChildCount()
+  if bufferEnd >= totalRows then bufferEnd = totalRows - 1
+  if bufferStart > bufferEnd then return
 
   nowSeconds = CreateObject("roDateTime").AsSeconds()
   hasExpiredProgram = false
 
-  for i = 0 to content.getChildCount() - 1
+  for i = bufferStart to bufferEnd
     row = content.getChild(i)
     if isValid(row)
       for j = 0 to row.getChildCount() - 1

--- a/components/ui/rowlist/JRRowList.xml
+++ b/components/ui/rowlist/JRRowList.xml
@@ -1,4 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <component name="JRRowList" extends="RowList">
-
+  <interface>
+    <!--
+      Set to true by the Program progress tick when it detects at least one
+      Program child whose broadcast window has ended (now >= PlayStart + PlayDuration).
+      Subclasses that display live Programs (HomeRows, ExtrasRowList) observe this
+      field to lazily refetch stale data. alwaysNotify fires the observer on every
+      set so subclasses can use their own in-flight guards for debouncing.
+    -->
+    <field id="programsExpired" type="boolean" alwaysNotify="true" value="false" />
+  </interface>
 </component>

--- a/source/utils/misc.bs
+++ b/source/utils/misc.bs
@@ -80,6 +80,23 @@ function secondsToTimestamp(totalSeconds as integer, addLeadingMinuteZero as boo
   return humanTime
 end function
 
+' Computes a broadcast program's elapsed-time percentage.
+' Programs are live broadcasts, not streamed media — so "progress" is
+' wall-clock elapsed, not UserData.PlayedPercentage.
+' Returns 0 (not 100) for finished programs because JRPoster only cleanly
+' removes the VideoProgressBar child when playedPercentage = 0.
+' @param playStart - epoch seconds when the program started (0 = unknown)
+' @param playDuration - program length in seconds (0 = unknown)
+' @param nowSeconds - current epoch seconds (injected for testability)
+' @return float in (0, 100) while airing, or 0 when not airing / invalid
+function computeProgramBroadcastProgress(playStart as integer, playDuration as integer, nowSeconds as integer) as float
+  if playStart <= 0 or playDuration <= 0 then return 0.0
+  elapsed = nowSeconds - playStart
+  if elapsed <= 0 then return 0.0
+  if elapsed >= playDuration then return 0.0
+  return (elapsed / playDuration) * 100.0
+end function
+
 ' Format time as 12 or 24 hour format based on system clock setting
 ' NOTE: This is NOT used by app's clock, only for displaying time in dialogs
 function formatTime(time) as string

--- a/source/utils/textureManager.bs
+++ b/source/utils/textureManager.bs
@@ -60,15 +60,23 @@ sub initTextureManager(contentRoot as object, itemSize as dynamic, focusXOffset 
       loadedRowRange: [-1, -1, -1, -1],
       focusedColumns: [],
       textureVisibleWidth: visibleWidth,
-      textureItemSpacing: itemSpacing,
-      textureManagerState: "init"
+      textureItemSpacing: itemSpacing
     })
   else
     ' Fields may already exist from a previous init — update layout values
     contentRoot.textureVisibleWidth = visibleWidth
     contentRoot.textureItemSpacing = itemSpacing
-    contentRoot.textureManagerState = "init"
   end if
+
+  ' textureManagerState is managed separately from the batch addFields because
+  ' JRRowList pre-adds it on the content root (via its content observer) so
+  ' the Program progress tick can subscribe to visibility transitions before
+  ' initTextureManager runs. addFields() fails on duplicate field names, so
+  ' keeping this out of the batch lets both call sites coexist safely.
+  if not contentRoot.hasField("textureManagerState")
+    contentRoot.addField("textureManagerState", "string", false)
+  end if
+  contentRoot.textureManagerState = "init"
 end sub
 
 ' Calculates the usable row width for determining how many items fit on screen.

--- a/tests/source/BaseTestSuite.spec.bs
+++ b/tests/source/BaseTestSuite.spec.bs
@@ -208,6 +208,35 @@ namespace tests
     end sub
 
     ' ===================================================================
+    ' TYPE CHECK HELPERS
+    ' Each BrightScript scalar has two equivalent runtime type names
+    ' (boxed "ro*" vs unboxed). Numeric types also span Float/Double for
+    ' the same semantic value. These helpers treat the whole equivalence
+    ' class as a single logical type so assertions don't flake on
+    ' legitimate numeric promotion or auto-boxing.
+    ' ===================================================================
+
+    protected function isStringType(value as dynamic) as boolean
+      typeStr = type(value)
+      return typeStr = "String" or typeStr = "roString"
+    end function
+
+    protected function isBooleanType(value as dynamic) as boolean
+      typeStr = type(value)
+      return typeStr = "Boolean" or typeStr = "roBoolean"
+    end function
+
+    protected function isIntegerType(value as dynamic) as boolean
+      typeStr = type(value)
+      return typeStr = "Integer" or typeStr = "roInteger" or typeStr = "roInt"
+    end function
+
+    protected function isFloatType(value as dynamic) as boolean
+      typeStr = type(value)
+      return typeStr = "Float" or typeStr = "roFloat" or typeStr = "Double" or typeStr = "roDouble"
+    end function
+
+    ' ===================================================================
     ' TEST HELPER METHODS
     ' Use these in individual tests to reset or access m.global safely
     ' ===================================================================

--- a/tests/source/integration/TypeConversion.spec.bs
+++ b/tests/source/integration/TypeConversion.spec.bs
@@ -4,29 +4,8 @@ namespace tests
   @suite("Type Conversion - Registry ↔ Settings Node")
   class TypeConversionTests extends tests.BaseTestSuite
 
-    ' Helper to check if type is string (handles both "String" and "roString")
-    private function isStringType(value as dynamic) as boolean
-      typeStr = type(value)
-      return typeStr = "String" or typeStr = "roString"
-    end function
-
-    ' Helper to check if type is boolean
-    private function isBooleanType(value as dynamic) as boolean
-      typeStr = type(value)
-      return typeStr = "Boolean" or typeStr = "roBoolean"
-    end function
-
-    ' Helper to check if type is integer
-    private function isIntegerType(value as dynamic) as boolean
-      typeStr = type(value)
-      return typeStr = "Integer" or typeStr = "roInteger" or typeStr = "roInt"
-    end function
-
-    ' Helper to check if type is float
-    private function isFloatType(value as dynamic) as boolean
-      typeStr = type(value)
-      return typeStr = "Float" or typeStr = "roFloat" or typeStr = "Double" or typeStr = "roDouble"
-    end function
+    ' Type-check helpers (isStringType/isBooleanType/isIntegerType/isFloatType)
+    ' live on BaseTestSuite so any spec can reuse them via m.*.
 
     '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
     @describe("valueToString() - Conversion to Registry Format")

--- a/tests/source/integration/registry/RoundTripConversion.spec.bs
+++ b/tests/source/integration/registry/RoundTripConversion.spec.bs
@@ -10,11 +10,7 @@ namespace tests
       super.setup()
     end sub
 
-    ' Helper to check if type is string (handles both "String" and "roString")
-    private function isStringType(value as dynamic) as boolean
-      typeStr = type(value)
-      return typeStr = "String" or typeStr = "roString"
-    end function
+    ' isStringType lives on BaseTestSuite; use m.isStringType.
 
     '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
     @describe("Round-Trip Tests - Save → Registry → Load → Verify")

--- a/tests/source/unit/utils/misc-computeProgramBroadcastProgress.spec.bs
+++ b/tests/source/unit/utils/misc-computeProgramBroadcastProgress.spec.bs
@@ -1,0 +1,84 @@
+
+namespace tests
+
+  @suite("misc.bs - computeProgramBroadcastProgress() Live Program Elapsed Percentage")
+  class ComputeProgramBroadcastProgressTests extends tests.BaseTestSuite
+
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    @describe("computeProgramBroadcastProgress(playStart, playDuration, nowSeconds)")
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+    @it("returns 50.0 when the program is airing halfway through")
+    function _()
+      result = computeProgramBroadcastProgress(1000, 100, 1050)
+      m.assertEqual(result, 50.0)
+    end function
+
+    @it("returns 1.0 one second after broadcast start")
+    function _()
+      result = computeProgramBroadcastProgress(1000, 100, 1001)
+      m.assertEqual(result, 1.0)
+    end function
+
+    @it("returns 99.0 one second before broadcast end")
+    function _()
+      result = computeProgramBroadcastProgress(1000, 100, 1099)
+      m.assertEqual(result, 99.0)
+    end function
+
+    @it("returns 0.0 exactly at broadcast start (elapsed == 0)")
+    function _()
+      result = computeProgramBroadcastProgress(1000, 100, 1000)
+      m.assertEqual(result, 0.0)
+    end function
+
+    @it("returns 0.0 exactly at broadcast end (elapsed == duration)")
+    function _()
+      result = computeProgramBroadcastProgress(1000, 100, 1100)
+      m.assertEqual(result, 0.0)
+    end function
+
+    @it("returns 0.0 when the current time is before broadcast start")
+    function _()
+      result = computeProgramBroadcastProgress(1000, 100, 500)
+      m.assertEqual(result, 0.0)
+    end function
+
+    @it("returns 0.0 when the current time is after broadcast end")
+    function _()
+      result = computeProgramBroadcastProgress(1000, 100, 2000)
+      m.assertEqual(result, 0.0)
+    end function
+
+    @it("returns 0.0 when playStart is invalid")
+    @params(0)
+    @params(-1)
+    function _(playStart)
+      result = computeProgramBroadcastProgress(playStart, 100, 50)
+      m.assertEqual(result, 0.0)
+    end function
+
+    @it("returns 0.0 when playDuration is invalid")
+    @params(0)
+    @params(-1)
+    function _(playDuration)
+      result = computeProgramBroadcastProgress(1000, playDuration, 1050)
+      m.assertEqual(result, 0.0)
+    end function
+
+    @it("computes 50.0 at epoch-scale realistic inputs")
+    function _()
+      ' 30-minute program, halfway through
+      result = computeProgramBroadcastProgress(1700000000, 1800, 1700000900)
+      m.assertEqual(result, 50.0)
+    end function
+
+    @it("returns a Float type (not Integer) so bar width math works correctly")
+    function _()
+      result = computeProgramBroadcastProgress(1000, 100, 1050)
+      m.assertTrue(Type(result) = "roFloat" or Type(result) = "Float", `expected Float but got ${Type(result)}`)
+    end function
+
+  end class
+
+end namespace

--- a/tests/source/unit/utils/misc-computeProgramBroadcastProgress.spec.bs
+++ b/tests/source/unit/utils/misc-computeProgramBroadcastProgress.spec.bs
@@ -76,7 +76,7 @@ namespace tests
     @it("returns a Float type (not Integer) so bar width math works correctly")
     function _()
       result = computeProgramBroadcastProgress(1000, 100, 1050)
-      m.assertTrue(Type(result) = "roFloat" or Type(result) = "Float", `expected Float but got ${Type(result)}`)
+      m.assertTrue(m.isFloatType(result), `expected Float/Double but got ${Type(result)}`)
     end function
 
   end class


### PR DESCRIPTION
Closes #470. Adds a self-updating progress bar to live `Program` items wherever they're rendered through `JRRowItem` — Home "On Now", Favorites, Search (via BrowseRowItem), and ItemDetails "Up Next" / "More on this Channel". Progress is derived from the broadcast window (`(now − StartDate) / (EndDate − StartDate)`) and refreshes every minute. When an airing program ends, the row self-heals by refetching fresh data so it never bleeds empty.

## Changes

- Add `computeProgramBroadcastProgress` pure helper in `misc.bs` with unit tests covering airing, boundary, invalid, and epoch-scale cases
- Split `textureManagerState` out of `initTextureManager`'s batch `addFields` call so other components can pre-add the field without colliding with Roku's atomic `addFields` semantics
- Add a universal 60s progress tick on `JRRowList` that rewrites `playedPercentage` on every `Program` child, gated on the existing `content.textureManagerState = "active"` signal (zero per-screen plumbing; all four row-list subclasses inherit it)
- Add a reactive bridge on `JRRowItem` that observes `playedPercentage` on bound Program content nodes and forwards writes to the live poster, with unconditional observer teardown on every render so recycled cells cannot leak observers onto stale content
- Expose a `programsExpired` field on `JRRowList` that the tick raises when at least one Program's broadcast window has ended
- Lazy-refetch `HomeRows` On Now via `LoadOnNowTask` when `programsExpired` fires (debounced by `m.isLoadingOnNow`, short-circuits if the user has no livetv section)
- Lazy-refetch `ExtrasRowList` TvChannel/Program rows via `LoadChannelProgramsTask` on expiry with dedicated refetch handlers that deliberately skip re-chaining to `LikeThisTask` (related content is stable across a session)

## Test plan

- [ ] Open Home — currently-airing programs in "On Now" show a progress bar at their correct initial position
- [ ] Sit on Home ~2 minutes — bars visibly tick forward
- [ ] Favorite a currently-airing program, open Favorites tab — bar appears and ticks
- [ ] Search a currently-airing program name — bar appears on the result in the Programs section and ticks
- [ ] Open a live TvChannel in ItemDetails — "Up Next" row's airing entry shows ticking bar
- [ ] Open a Program in ItemDetails — "More on this Channel" row shows ticking bar
- [ ] Navigate to Settings and back — bars immediately up-to-date (immediate tick on re-activation, no stale 60s window)
- [ ] Switch tabs Home → Favorites → Home — ticking resumes
- [ ] Exit Home — no crashes, no orphaned timer callbacks after destroy
- [ ] Disable the LiveTV section in Home layout — no regressions, no wasted API calls
- [ ] Fast-scroll the On Now row — no stale percentages bleed onto Episode/Movie cells in adjacent rows (validates the unconditional observer teardown on recycling)
- [ ] Wait for an airing program to actually end — row self-heals within ~60s with fresh data from `/LiveTv/Programs/Recommended`
- [ ] Continue Watching and Next Up bars remain unchanged (regression check)