### PR TITLE
fix: trickplay carousel not rendering after boolean prefix refactor

### DIFF
--- a/components/video/TrickplayCarousel.bs
+++ b/components/video/TrickplayCarousel.bs
@@ -449,6 +449,9 @@ end sub
 ' Called when visible field changes
 ' Performs initial tile caching and displays posters when carousel first appears
 sub onIsVisibleChanged()
+  ' Sync built-in Group visible — isVisible is a custom field that doesn't control rendering
+  m.top.visible = m.top.isVisible
+
   if not m.top.isVisible
     ' Reset velocity tracking when carousel hides (scrubbing session ended)
     m.currentVelocity = 0

--- a/components/video/TrickplayCarousel.bs
+++ b/components/video/TrickplayCarousel.bs
@@ -446,7 +446,7 @@ sub onPlaybackPositionChanged()
   end if
 end sub
 
-' Called when visible field changes
+' Called when isVisible field changes
 ' Performs initial tile caching and displays posters when carousel first appears
 sub onIsVisibleChanged()
   ' Sync built-in Group visible — isVisible is a custom field that doesn't control rendering


### PR DESCRIPTION
Fixes #488 — Introduced in v2.11.0

The boolean prefix refactor renamed TrickplayCarousel's custom `visible` field to `isVisible`. Before the rename, `visible` shadowed the built-in Group property so setting it controlled both the callback and rendering. After the rename, the built-in `visible` stayed `false` forever — the carousel ran its logic but never rendered.

## Changes

- Sync the built-in `visible` property from `isVisible` at the top of `onIsVisibleChanged()` so the carousel actually renders when shown