### PR TITLE
fix: validate URLs before HTTP requests to prevent Invalid-to-String crash

### DIFF
--- a/components/ItemGrid/ItemGridOptions.bs
+++ b/components/ItemGrid/ItemGridOptions.bs
@@ -212,12 +212,12 @@ sub toggleFavorite()
     m.favoriteMenu.iconUri = "pkg:/images/icons/favorite_selected.png"
     m.favoriteMenu.focusedIconUri = "pkg:/images/icons/favorite_selected.png"
     req = GetApi().BuildMarkFavoriteRequest(m.selectedFavoriteItem.id)
-    if isValid(req) then SubmitSideEffect(req)
+    SubmitSideEffect(req)
   else
     m.favoriteMenu.iconUri = "pkg:/images/icons/favorite.png"
     m.favoriteMenu.focusedIconUri = "pkg:/images/icons/favorite.png"
     req = GetApi().BuildUnmarkFavoriteRequest(m.selectedFavoriteItem.id)
-    if isValid(req) then SubmitSideEffect(req)
+    SubmitSideEffect(req)
   end if
   ' Make sure we set the Favorite Heart color for the appropriate child
   setHeartColor("#cc3333")

--- a/components/ItemGrid/LoadVideoContentTask.bs
+++ b/components/ItemGrid/LoadVideoContentTask.bs
@@ -454,12 +454,21 @@ sub setupVideoContentWithAuth(video, mediaSourceId, audioStreamIdx)
       ' if the domain of the URI is local to the server,
       ' create a new URI by appending the received path to the server URL
       ' later we will substitute the users provided URL for this case
-      if isValid(uri[4])
-        localUrl = buildURL(uri[4])
-        if isValid(localUrl)
-          video.content.url = localUrl
-        end if
+      if not isValid(uri[4])
+        m.log.error("Localhost stream has no path component", "sourceUrl", m.playbackInfo.MediaSources[0].Path)
+        m.top.errorMsg = translate(translationKeys.ErrorAnErrorWasEncounteredWhilePlaying)
+        video.content = invalid
+        return
       end if
+
+      localUrl = buildURL(uri[4])
+      if not isValid(localUrl)
+        m.log.error("Failed to build localhost stream URL — server URL not set", "path", uri[4])
+        m.top.errorMsg = translate(translationKeys.ErrorAnErrorWasEncounteredWhilePlaying)
+        video.content = invalid
+        return
+      end if
+      video.content.url = localUrl
     else
       ' External stream - use raw URL without modification
       fullyExternal = true

--- a/components/ItemGrid/LoadVideoContentTask.bs
+++ b/components/ItemGrid/LoadVideoContentTask.bs
@@ -402,7 +402,14 @@ sub LoadItems_AddVideoContent(video as object, mediaSourceId as dynamic, audioSt
     end if
     ' Get transcoding reason
     video.transcodeReasons = getTranscodeReasons(m.playbackInfo.MediaSources[0].TranscodingUrl)
-    video.content.url = buildURL(m.playbackInfo.MediaSources[0].TranscodingUrl)
+    transcodingUrl = buildURL(m.playbackInfo.MediaSources[0].TranscodingUrl)
+    if not isValid(transcodingUrl)
+      m.log.error("Failed to build transcoding URL — server URL not set", "itemId", video.id)
+      m.top.errorMsg = translate(translationKeys.ErrorAnErrorWasEncounteredWhilePlaying)
+      video.content = invalid
+      return
+    end if
+    video.content.url = transcodingUrl
     video.isTranscoded = true
 
     ' If DoVi preservation caused this transcode, flag that direct play is a viable buffer-overflow fallback.
@@ -448,7 +455,10 @@ sub setupVideoContentWithAuth(video, mediaSourceId, audioStreamIdx)
       ' create a new URI by appending the received path to the server URL
       ' later we will substitute the users provided URL for this case
       if isValid(uri[4])
-        video.content.url = buildURL(uri[4])
+        localUrl = buildURL(uri[4])
+        if isValid(localUrl)
+          video.content.url = localUrl
+        end if
       end if
     else
       ' External stream - use raw URL without modification
@@ -468,7 +478,14 @@ sub setupVideoContentWithAuth(video, mediaSourceId, audioStreamIdx)
       params.MediaSourceId = mediaSourceId
     end if
 
-    video.content.url = buildURL(Substitute("Videos/{0}/stream", video.id), params)
+    streamUrl = buildURL(Substitute("Videos/{0}/stream", video.id), params)
+    if not isValid(streamUrl)
+      m.log.error("Failed to build stream URL — server URL not set", "itemId", video.id)
+      m.top.errorMsg = translate(translationKeys.ErrorAnErrorWasEncounteredWhilePlaying)
+      video.content = invalid
+      return
+    end if
+    video.content.url = streamUrl
   end if
 
   ' Apply Jellyfin authentication only for internal streams

--- a/components/api/ApiTask.bs
+++ b/components/api/ApiTask.bs
@@ -65,6 +65,17 @@ function executeRequest(req as object) as object
     end if
   end if
 
+  if not isValid(req.url) or req.url = ""
+    print "[ApiTask] request rejected: url is invalid or empty"
+    return {
+      requestId: req.requestId,
+      ok: false,
+      statusCode: 0,
+      json: invalid,
+      text: ""
+    }
+  end if
+
   r = rr_Requests().request(method, req.url, args)
 
   return {

--- a/components/api/SideEffectTask.bs
+++ b/components/api/SideEffectTask.bs
@@ -40,5 +40,10 @@ sub executeSideEffect()
     end if
   end if
 
+  if not isValid(req.url) or req.url = ""
+    print "[SideEffectTask] request rejected: url is invalid or empty"
+    return
+  end if
+
   rr_Requests().request(method, req.url, args)
 end sub

--- a/components/mediaPlayers/AudioPlayer.bs
+++ b/components/mediaPlayers/AudioPlayer.bs
@@ -40,5 +40,5 @@ sub ReportPlayback(state as string)
 
   ' Report playstate via side-effect task
   req = GetApi().BuildPlaystateRequest(state, params)
-  if isValid(req) then SubmitSideEffect(req)
+  SubmitSideEffect(req)
 end sub

--- a/components/tasks/FontDownloadTask.bs
+++ b/components/tasks/FontDownloadTask.bs
@@ -13,7 +13,15 @@ sub downloadFallbackFont()
   authArgs = { headers: { Authorization: buildAuthHeader() }, timeout: 10000, useCache: false }
 
   ' Check if server supports fallback fonts
-  r = rr_Requests().get(buildURL("/system/configuration/encoding"), authArgs)
+  encodingUrl = buildURL("/system/configuration/encoding")
+  if not isValid(encodingUrl)
+    print "FontDownloadTask: Cannot build URL — server URL not set"
+    m.top.errorMessage = "Server URL not configured"
+    m.top.isFontDownloadSuccess = false
+    m.top.isFontDownloadCompleted = true
+    return
+  end if
+  r = rr_Requests().get(encodingUrl, authArgs)
   if not r.ok or not isValid(r.json) or not r.json.EnableFallbackFont
     print "FontDownloadTask: Server does not support fallback fonts"
     m.top.errorMessage = "Server does not support fallback fonts"
@@ -24,7 +32,15 @@ sub downloadFallbackFont()
 
   ' Get list of available fonts
   re = CreateObject("roRegex", "Name.:.(.*?).,.Size", "s")
-  r = rr_Requests().get(buildURL("FallbackFont/Fonts"), authArgs)
+  fontsUrl = buildURL("FallbackFont/Fonts")
+  if not isValid(fontsUrl)
+    print "FontDownloadTask: Cannot build URL — server URL not set"
+    m.top.errorMessage = "Server URL not configured"
+    m.top.isFontDownloadSuccess = false
+    m.top.isFontDownloadCompleted = true
+    return
+  end if
+  r = rr_Requests().get(fontsUrl, authArgs)
   if not r.ok or r.text = ""
     print "FontDownloadTask: Failed to get font list from server"
     m.top.errorMessage = "Failed to get font list from server"

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -1385,7 +1385,7 @@ sub ReportPlayback(state = "update" as string)
 
   ' Report playstate via side-effect task
   req = GetApi().BuildPlaystateRequest(state, params)
-  if isValid(req) then SubmitSideEffect(req)
+  SubmitSideEffect(req)
 
   m.log.debug("end ReportPlayback", state, int(m.top.position))
 end sub

--- a/source/api/ApiClient.bs
+++ b/source/api/ApiClient.bs
@@ -56,9 +56,9 @@ class ApiClient
 
     if m.getApiVersion() >= 2
       mergedParams.userId = userId
-      return { method: "GET", url: buildURL(Substitute("/Items/{0}", itemId), mergedParams) }
+      return m.validatedReq("GET", buildURL(Substitute("/Items/{0}", itemId), mergedParams))
     end if
-    return { method: "GET", url: buildURL(Substitute("/users/{0}/items/{1}", userId, itemId), mergedParams) }
+    return m.validatedReq("GET", buildURL(Substitute("/users/{0}/items/{1}", userId, itemId), mergedParams))
   end function
 
   ' Build a request AA to get a single item WITHOUT image/version field injection.
@@ -71,9 +71,9 @@ class ApiClient
 
     if m.getApiVersion() >= 2
       params.userId = userId
-      return { method: "GET", url: buildURL(Substitute("/Items/{0}", itemId), params) }
+      return m.validatedReq("GET", buildURL(Substitute("/Items/{0}", itemId), params))
     end if
-    return { method: "GET", url: buildURL(Substitute("/users/{0}/items/{1}", userId, itemId), params) }
+    return m.validatedReq("GET", buildURL(Substitute("/users/{0}/items/{1}", userId, itemId), params))
   end function
 
   ' Build a request AA for GetItemsByQuery, for use with fetchRes() or fetchJson().
@@ -88,9 +88,9 @@ class ApiClient
     if m.getApiVersion() >= 2
       queryParams = { userId: userId }
       queryParams.append(mergedParams)
-      return { method: "GET", url: buildURL("/items/", queryParams) }
+      return m.validatedReq("GET", buildURL("/items/", queryParams))
     end if
-    return { method: "GET", url: buildURL(Substitute("/users/{0}/items", userId), mergedParams) }
+    return m.validatedReq("GET", buildURL(Substitute("/users/{0}/items", userId), mergedParams))
   end function
 
   ' Build a request AA for GetResumeItems (Continue Watching), for use with fetchRes() or fetchJson().
@@ -104,9 +104,9 @@ class ApiClient
     if m.getApiVersion() >= 2
       queryParams = { userId: userId }
       queryParams.append(mergedParams)
-      return { method: "GET", url: buildURL("/UserItems/Resume", queryParams) }
+      return m.validatedReq("GET", buildURL("/UserItems/Resume", queryParams))
     end if
-    return { method: "GET", url: buildURL(Substitute("/users/{0}/items/resume", userId), mergedParams) }
+    return m.validatedReq("GET", buildURL(Substitute("/users/{0}/items/resume", userId), mergedParams))
   end function
 
   ' Build a request AA for GetLatestMedia, for use with fetchRes() or fetchJson().
@@ -122,9 +122,9 @@ class ApiClient
     if m.getApiVersion() >= 2
       queryParams = { userId: userId }
       queryParams.append(mergedParams)
-      return { method: "GET", url: buildURL("/Items/Latest", queryParams) }
+      return m.validatedReq("GET", buildURL("/Items/Latest", queryParams))
     end if
-    return { method: "GET", url: buildURL(Substitute("/users/{0}/items/latest", userId), mergedParams) }
+    return m.validatedReq("GET", buildURL(Substitute("/users/{0}/items/latest", userId), mergedParams))
   end function
 
   ' ═══════════════════════════════════════════════════════════════════════════
@@ -146,7 +146,7 @@ class ApiClient
     if userId = "" then return invalid
     mergedParams = m.injectDefaults(params)
     mergedParams.UserId = userId
-    return { method: "GET", url: buildURL(Substitute("/shows/{0}/seasons", seriesId), mergedParams) }
+    return m.validatedReq("GET", buildURL(Substitute("/shows/{0}/seasons", seriesId), mergedParams))
   end function
 
   ' Build a request AA for GetEpisodes, for use with fetchRes() or fetchJson().
@@ -160,7 +160,7 @@ class ApiClient
     mergedParams = m.injectDefaults(params)
     mergedParams.UserId = userId
 
-    return { method: "GET", url: buildURL(Substitute("/shows/{0}/episodes", seriesId), mergedParams) }
+    return m.validatedReq("GET", buildURL(Substitute("/shows/{0}/episodes", seriesId), mergedParams))
   end function
 
   ' ═══════════════════════════════════════════════════════════════════════════
@@ -170,9 +170,9 @@ class ApiClient
   ' Build a request AA for GetArtistByName, for use with fetchJson().
   ' @param name - Artist name (will be URI-encoded)
   ' @param params - Optional query parameters
-  ' @returns Request AA: { method, url }
-  function BuildGetArtistByNameRequest(name as string, params = {} as object) as object
-    return { method: "GET", url: buildURL(Substitute("/artists/{0}", name.EncodeUriComponent()), params) }
+  ' @returns Request AA: { method, url } or invalid if server URL not set
+  function BuildGetArtistByNameRequest(name as string, params = {} as object) as dynamic
+    return m.validatedReq("GET", buildURL(Substitute("/artists/{0}", name.EncodeUriComponent()), params))
   end function
 
   ' Build a request AA to fetch all artists, for use with fetchRes() or fetchJson().
@@ -184,7 +184,7 @@ class ApiClient
     if userId = "" then return invalid
     mergedParams = m.injectDefaults(params)
     mergedParams.UserId = userId
-    return { method: "GET", url: buildURL("/artists", mergedParams) }
+    return m.validatedReq("GET", buildURL("/artists", mergedParams))
   end function
 
   ' Build a request AA for GetPersons, for use with fetchRes() or fetchJson().
@@ -196,7 +196,7 @@ class ApiClient
     if userId = "" then return invalid
     mergedParams = m.injectDefaults(params)
     mergedParams.UserId = userId
-    return { method: "GET", url: buildURL("/persons", mergedParams) }
+    return m.validatedReq("GET", buildURL("/persons", mergedParams))
   end function
 
   ' Build a request AA to fetch all album artists, for use with fetchRes() or fetchJson().
@@ -208,15 +208,15 @@ class ApiClient
     if userId = "" then return invalid
     mergedParams = m.injectDefaults(params)
     mergedParams.UserId = userId
-    return { method: "GET", url: buildURL("/artists/albumartists", mergedParams) }
+    return m.validatedReq("GET", buildURL("/artists/albumartists", mergedParams))
   end function
 
   ' Build a request AA to get similar artists, for use with fetchRes() or fetchJson().
   ' @param itemId - The artist item ID
   ' @param params - Optional query parameters (userId, limit, etc.)
-  ' @returns Request AA: { method, url }
-  function BuildGetArtistSimilarRequest(itemId as string, params = {} as object) as object
-    return { method: "GET", url: buildURL(Substitute("/Artists/{0}/Similar", itemId), params) }
+  ' @returns Request AA: { method, url } or invalid if server URL not set
+  function BuildGetArtistSimilarRequest(itemId as string, params = {} as object) as dynamic
+    return m.validatedReq("GET", buildURL(Substitute("/Artists/{0}/Similar", itemId), params))
   end function
 
   ' ═══════════════════════════════════════════════════════════════════════════
@@ -235,7 +235,7 @@ class ApiClient
     mergedParams.append(params)
     mergedParams.UserId = userId
 
-    return { method: "GET", url: buildURL(Substitute("/playlists/{0}/items", playlistId), mergedParams) }
+    return m.validatedReq("GET", buildURL(Substitute("/playlists/{0}/items", playlistId), mergedParams))
   end function
 
   ' ═══════════════════════════════════════════════════════════════════════════
@@ -254,7 +254,7 @@ class ApiClient
     mergedParams.append(params)
     mergedParams.UserId = userId
 
-    return { method: "GET", url: buildURL(Substitute("/items/{0}/instantmix", itemId), mergedParams) }
+    return m.validatedReq("GET", buildURL(Substitute("/items/{0}/instantmix", itemId), mergedParams))
   end function
 
   ' Build a request AA for GetIntros, for use with fetchJson().
@@ -265,29 +265,29 @@ class ApiClient
     if userId = "" then return invalid
 
     if m.getApiVersion() >= 2
-      return { method: "GET", url: buildURL(Substitute("/Items/{0}/Intros", itemId)) }
+      return m.validatedReq("GET", buildURL(Substitute("/Items/{0}/Intros", itemId)))
     end if
-    return { method: "GET", url: buildURL(Substitute("/users/{0}/items/{1}/intros", userId, itemId)) }
+    return m.validatedReq("GET", buildURL(Substitute("/users/{0}/items/{1}/intros", userId, itemId)))
   end function
 
   ' Build a request AA for GetMediaSegments, for use with fetchJson().
   ' Only available on Jellyfin 10.10.0+ servers.
   ' @param itemId - The item ID
   ' @param includeSegmentTypes - Optional comma-separated segment types to filter (e.g., "Intro,Outro")
-  ' @returns Request AA: { method, url }
-  function BuildGetMediaSegmentsRequest(itemId as string, includeSegmentTypes = "" as string) as object
+  ' @returns Request AA: { method, url } or invalid if server URL not set
+  function BuildGetMediaSegmentsRequest(itemId as string, includeSegmentTypes = "" as string) as dynamic
     params = {}
     if includeSegmentTypes <> ""
       params.includeSegmentTypes = includeSegmentTypes
     end if
-    return { method: "GET", url: buildURL(Substitute("/MediaSegments/{0}", itemId), params) }
+    return m.validatedReq("GET", buildURL(Substitute("/MediaSegments/{0}", itemId), params))
   end function
 
   ' Build a request AA for GetItemLyrics, for use with fetchJson().
   ' @param itemId - The Audio item ID
-  ' @returns Request AA: { method, url }
-  function BuildGetItemLyricsRequest(itemId as string) as object
-    return { method: "GET", url: buildURL(Substitute("Audio/{0}/Lyrics", itemId)) }
+  ' @returns Request AA: { method, url } or invalid if server URL not set
+  function BuildGetItemLyricsRequest(itemId as string) as dynamic
+    return m.validatedReq("GET", buildURL(Substitute("Audio/{0}/Lyrics", itemId)))
   end function
 
   ' ═══════════════════════════════════════════════════════════════════════════
@@ -297,9 +297,11 @@ class ApiClient
   ' Build a request AA for PostPlaybackInfo, for use with fetchJson().
   ' @param itemId - The item ID
   ' @param postData - Request body data (DeviceProfile, MediaSourceId, etc.)
-  ' @returns Request AA: { method, url, body }
-  function BuildPostPlaybackInfoRequest(itemId as string, postData as object) as object
-    return { method: "POST", url: buildURL(Substitute("/items/{0}/playbackinfo", itemId)), body: FormatJson(postData), headers: { "Content-Type": "application/json" } }
+  ' @returns Request AA: { method, url, body } or invalid if server URL not set
+  function BuildPostPlaybackInfoRequest(itemId as string, postData as object) as dynamic
+    url = buildURL(Substitute("/items/{0}/playbackinfo", itemId))
+    if not isValid(url) then return invalid
+    return { method: "POST", url: url, body: FormatJson(postData), headers: { "Content-Type": "application/json" } }
   end function
 
 
@@ -309,11 +311,11 @@ class ApiClient
   ' @returns Request AA: { method, url } or invalid if no userId (V1 only)
   function BuildGetLocalTrailersRequest(itemId as string) as dynamic
     if m.getApiVersion() >= 2
-      return { method: "GET", url: buildURL(Substitute("/Items/{0}/LocalTrailers", itemId), {}) }
+      return m.validatedReq("GET", buildURL(Substitute("/Items/{0}/LocalTrailers", itemId), {}))
     end if
     userId = m.getUserId()
     if userId = "" then return invalid
-    return { method: "GET", url: buildURL(Substitute("/users/{0}/items/{1}/localtrailers", userId, itemId), {}) }
+    return m.validatedReq("GET", buildURL(Substitute("/users/{0}/items/{1}/localtrailers", userId, itemId), {}))
   end function
 
   ' Build a request AA for GetSpecialFeatures, for use with fetchRes() or fetchJson().
@@ -322,11 +324,11 @@ class ApiClient
   ' @returns Request AA: { method, url } or invalid if no userId (V1 only)
   function BuildGetSpecialFeaturesRequest(itemId as string) as dynamic
     if m.getApiVersion() >= 2
-      return { method: "GET", url: buildURL(Substitute("/Items/{0}/SpecialFeatures", itemId), {}) }
+      return m.validatedReq("GET", buildURL(Substitute("/Items/{0}/SpecialFeatures", itemId), {}))
     end if
     userId = m.getUserId()
     if userId = "" then return invalid
-    return { method: "GET", url: buildURL(Substitute("/users/{0}/items/{1}/specialfeatures", userId, itemId), {}) }
+    return m.validatedReq("GET", buildURL(Substitute("/users/{0}/items/{1}/specialfeatures", userId, itemId), {}))
   end function
 
   ' Build a request AA to mark an item as favorite, for use with SubmitSideEffect().
@@ -337,9 +339,9 @@ class ApiClient
     if userId = "" then return invalid
 
     if m.getApiVersion() >= 2
-      return { method: "POST", url: buildURL(Substitute("/UserFavoriteItems/{0}", itemId), { userId: userId }) }
+      return m.validatedReq("POST", buildURL(Substitute("/UserFavoriteItems/{0}", itemId), { userId: userId }))
     end if
-    return { method: "POST", url: buildURL(Substitute("users/{0}/favoriteitems/{1}", userId, itemId)) }
+    return m.validatedReq("POST", buildURL(Substitute("users/{0}/favoriteitems/{1}", userId, itemId)))
   end function
 
   ' Build a request AA to unmark an item as favorite, for use with SubmitSideEffect().
@@ -350,9 +352,9 @@ class ApiClient
     if userId = "" then return invalid
 
     if m.getApiVersion() >= 2
-      return { method: "DELETE", url: buildURL(Substitute("/UserFavoriteItems/{0}", itemId), { userId: userId }) }
+      return m.validatedReq("DELETE", buildURL(Substitute("/UserFavoriteItems/{0}", itemId), { userId: userId }))
     end if
-    return { method: "DELETE", url: buildURL(Substitute("users/{0}/favoriteitems/{1}", userId, itemId)) }
+    return m.validatedReq("DELETE", buildURL(Substitute("users/{0}/favoriteitems/{1}", userId, itemId)))
   end function
 
   ' Build a request AA to mark an item as played, for use with SubmitSideEffect().
@@ -370,9 +372,9 @@ class ApiClient
 
     if m.getApiVersion() >= 2
       params.userId = userId
-      return { method: "POST", url: buildURL(Substitute("/UserPlayedItems/{0}", itemId), params) }
+      return m.validatedReq("POST", buildURL(Substitute("/UserPlayedItems/{0}", itemId), params))
     end if
-    return { method: "POST", url: buildURL(Substitute("users/{0}/playeditems/{1}", userId, itemId), params) }
+    return m.validatedReq("POST", buildURL(Substitute("users/{0}/playeditems/{1}", userId, itemId), params))
   end function
 
   ' Build a request AA to mark an item as unplayed, for use with SubmitSideEffect().
@@ -383,16 +385,16 @@ class ApiClient
     if userId = "" then return invalid
 
     if m.getApiVersion() >= 2
-      return { method: "DELETE", url: buildURL(Substitute("/UserPlayedItems/{0}", itemId), { userId: userId }) }
+      return m.validatedReq("DELETE", buildURL(Substitute("/UserPlayedItems/{0}", itemId), { userId: userId }))
     end if
-    return { method: "DELETE", url: buildURL(Substitute("users/{0}/playeditems/{1}", userId, itemId)) }
+    return m.validatedReq("DELETE", buildURL(Substitute("users/{0}/playeditems/{1}", userId, itemId)))
   end function
 
   ' Build a request AA to delete an item, for use with SubmitSideEffect().
   ' @param itemId - The item ID to delete
   ' @returns Request AA: { method, url }
   function BuildDeleteItemRequest(itemId as string) as dynamic
-    return { method: "DELETE", url: buildURL(Substitute("/items/{0}", itemId)) }
+    return m.validatedReq("DELETE", buildURL(Substitute("/items/{0}", itemId)))
   end function
 
 
@@ -426,9 +428,11 @@ class ApiClient
       return invalid
     end if
 
+    url = buildURL(path)
+    if not isValid(url) then return invalid
     return {
       method: "POST",
-      url: buildURL(path),
+      url: url,
       body: FormatJson(merged),
       headers: { "Content-Type": "application/json" }
     }
@@ -436,11 +440,13 @@ class ApiClient
 
   ' Build a request AA to post full session capabilities, for use with SubmitSideEffect().
   ' @param capabilities - Device capabilities AA from getDeviceCapabilities()
-  ' @returns Request AA: { method, url, body, headers }
-  function BuildPostSessionCapabilitiesRequest(capabilities as object) as object
+  ' @returns Request AA: { method, url, body, headers } or invalid if server URL not set
+  function BuildPostSessionCapabilitiesRequest(capabilities as object) as dynamic
+    url = buildURL("/Sessions/Capabilities/Full")
+    if not isValid(url) then return invalid
     return {
       method: "POST",
-      url: buildURL("/Sessions/Capabilities/Full"),
+      url: url,
       body: FormatJson(capabilities),
       headers: { "Content-Type": "application/json" }
     }
@@ -448,9 +454,9 @@ class ApiClient
 
   ' Build a request AA to get active sessions, for use with fetchJson().
   ' @param params - Query parameters (e.g. { deviceId: "..." })
-  ' @returns Request AA: { method, url }
-  function BuildGetSessionsRequest(params = {} as object) as object
-    return { method: "GET", url: buildURL("/sessions", params) }
+  ' @returns Request AA: { method, url } or invalid if server URL not set
+  function BuildGetSessionsRequest(params = {} as object) as dynamic
+    return m.validatedReq("GET", buildURL("/sessions", params))
   end function
 
   ' ═══════════════════════════════════════════════════════════════════════════
@@ -469,9 +475,9 @@ class ApiClient
   ' ═══════════════════════════════════════════════════════════════════════════
 
   ' Build a request AA for GetBrandingConfiguration, for use with fetchRes() or fetchJson().
-  ' @returns Request AA: { method, url }
-  function BuildGetBrandingConfigurationRequest() as object
-    return { method: "GET", url: buildURL("/branding/configuration") }
+  ' @returns Request AA: { method, url } or invalid if server URL not set
+  function BuildGetBrandingConfigurationRequest() as dynamic
+    return m.validatedReq("GET", buildURL("/branding/configuration"))
   end function
 
   ' ═══════════════════════════════════════════════════════════════════════════
@@ -546,9 +552,9 @@ class ApiClient
     userId = m.getUserId()
     if userId = "" then return invalid
     if m.getApiVersion() >= 2
-      return { method: "GET", url: buildURL("/UserViews", { userId: userId }) }
+      return m.validatedReq("GET", buildURL("/UserViews", { userId: userId }))
     end if
-    return { method: "GET", url: buildURL(Substitute("/users/{0}/views", userId), {}) }
+    return m.validatedReq("GET", buildURL(Substitute("/users/{0}/views", userId), {}))
   end function
 
   ' ═══════════════════════════════════════════════════════════════════════════
@@ -564,7 +570,7 @@ class ApiClient
     if userId = "" then return invalid
     mergedParams = m.injectDefaults(params)
     mergedParams.UserId = userId
-    return { method: "GET", url: buildURL("/shows/nextup", mergedParams) }
+    return m.validatedReq("GET", buildURL("/shows/nextup", mergedParams))
   end function
 
   ' ═══════════════════════════════════════════════════════════════════════════
@@ -573,17 +579,17 @@ class ApiClient
 
   ' Build a request AA for GetAdditionalParts, for use with fetchRes() or fetchJson().
   ' @param itemId - The video item ID
-  ' @returns Request AA: { method, url }
-  function BuildGetAdditionalPartsRequest(itemId as string) as object
-    return { method: "GET", url: buildURL(Substitute("/videos/{0}/additionalparts", itemId), {}) }
+  ' @returns Request AA: { method, url } or invalid if server URL not set
+  function BuildGetAdditionalPartsRequest(itemId as string) as dynamic
+    return m.validatedReq("GET", buildURL(Substitute("/videos/{0}/additionalparts", itemId), {}))
   end function
 
   ' Build a request AA to get similar items, for use with fetchRes() or fetchJson().
   ' @param itemId - The item ID
   ' @param params - Optional query parameters (userId, limit, etc.)
-  ' @returns Request AA: { method, url }
-  function BuildGetSimilarItemsRequest(itemId as string, params = {} as object) as object
-    return { method: "GET", url: buildURL(Substitute("/Items/{0}/Similar", itemId), params) }
+  ' @returns Request AA: { method, url } or invalid if server URL not set
+  function BuildGetSimilarItemsRequest(itemId as string, params = {} as object) as dynamic
+    return m.validatedReq("GET", buildURL(Substitute("/Items/{0}/Similar", itemId), params))
   end function
 
   ' ═══════════════════════════════════════════════════════════════════════════
@@ -592,9 +598,9 @@ class ApiClient
 
   ' Build a request AA for GetFilters, for use with fetchRes() or fetchJson().
   ' @param params - Query parameters (userid, parentid, includeitemtypes, etc.)
-  ' @returns Request AA: { method, url }
-  function BuildGetFiltersRequest(params = {} as object) as object
-    return { method: "GET", url: buildURL("/items/filters", params) }
+  ' @returns Request AA: { method, url } or invalid if server URL not set
+  function BuildGetFiltersRequest(params = {} as object) as dynamic
+    return m.validatedReq("GET", buildURL("/items/filters", params))
   end function
 
   ' ═══════════════════════════════════════════════════════════════════════════
@@ -606,9 +612,9 @@ class ApiClient
   ' @param id - Item ID
   ' @param imageType - Type of image (e.g. "logo", "Primary")
   ' @param imageIndex - Image index (default 0)
-  ' @returns Request AA: { method, url }
-  function BuildHeadItemImageRequest(id as string, imageType as string, imageIndex = 0 as integer) as object
-    return { method: "HEAD", url: buildURL(Substitute("/items/{0}/images/{1}/{2}", id, imageType, imageIndex.toStr()), {}) }
+  ' @returns Request AA: { method, url } or invalid if server URL not set
+  function BuildHeadItemImageRequest(id as string, imageType as string, imageIndex = 0 as integer) as dynamic
+    return m.validatedReq("HEAD", buildURL(Substitute("/items/{0}/images/{1}/{2}", id, imageType, imageIndex.toStr()), {}))
   end function
 
   ' Get image URL
@@ -640,25 +646,25 @@ class ApiClient
 
   ' Build a request AA to fetch Live TV channels, for use with fetchRes() or fetchJson().
   ' @param params - Query parameters
-  ' @returns Request AA: { method, url }
-  function BuildGetLiveTVChannelsRequest(params = {} as object) as object
-    return { method: "GET", url: buildURL("/livetv/channels", params) }
+  ' @returns Request AA: { method, url } or invalid if server URL not set
+  function BuildGetLiveTVChannelsRequest(params = {} as object) as dynamic
+    return m.validatedReq("GET", buildURL("/livetv/channels", params))
   end function
 
   ' Build a request AA for GetLiveTVPrograms (full EPG search), for use with fetchRes() or fetchJson().
   ' Mirrors GetLiveTVPrograms(): applies injectDefaults.
   ' @param params - Query parameters (SearchTerm, Limit, etc.)
-  ' @returns Request AA: { method, url }
-  function BuildGetLiveTVProgramsRequest(params = {} as object) as object
+  ' @returns Request AA: { method, url } or invalid if server URL not set
+  function BuildGetLiveTVProgramsRequest(params = {} as object) as dynamic
     mergedParams = m.injectDefaults(params)
-    return { method: "GET", url: buildURL("/livetv/programs", mergedParams) }
+    return m.validatedReq("GET", buildURL("/livetv/programs", mergedParams))
   end function
 
   ' Build a request AA to get recommended Live TV programs (On Now), for use with fetchRes() or fetchJson().
   ' @param params - Query parameters (userId, isAiring, limit, etc.)
-  ' @returns Request AA: { method, url }
-  function BuildGetLiveTvRecommendedProgramsRequest(params = {} as object) as object
-    return { method: "GET", url: buildURL("/LiveTv/Programs/Recommended", params) }
+  ' @returns Request AA: { method, url } or invalid if server URL not set
+  function BuildGetLiveTvRecommendedProgramsRequest(params = {} as object) as dynamic
+    return m.validatedReq("GET", buildURL("/LiveTv/Programs/Recommended", params))
   end function
 
   ' ═══════════════════════════════════════════════════════════════════════════
@@ -667,9 +673,9 @@ class ApiClient
 
   ' Build a request AA to fetch studios, for use with fetchRes() or fetchJson().
   ' @param params - Query parameters
-  ' @returns Request AA: { method, url }
-  function BuildGetStudiosRequest(params = {} as object) as object
-    return { method: "GET", url: buildURL("/studios", params) }
+  ' @returns Request AA: { method, url } or invalid if server URL not set
+  function BuildGetStudiosRequest(params = {} as object) as dynamic
+    return m.validatedReq("GET", buildURL("/studios", params))
   end function
 
   ' ═══════════════════════════════════════════════════════════════════════════
@@ -678,9 +684,9 @@ class ApiClient
 
   ' Build a request AA to fetch genres, for use with fetchRes() or fetchJson().
   ' @param params - Query parameters
-  ' @returns Request AA: { method, url }
-  function BuildGetGenresRequest(params = {} as object) as object
-    return { method: "GET", url: buildURL("/genres", params) }
+  ' @returns Request AA: { method, url } or invalid if server URL not set
+  function BuildGetGenresRequest(params = {} as object) as dynamic
+    return m.validatedReq("GET", buildURL("/genres", params))
   end function
 
   ' ═══════════════════════════════════════════════════════════════════════════
@@ -690,19 +696,21 @@ class ApiClient
   ' Build a request AA to fetch a single Live TV program, for use with fetchRes() or fetchJson().
   ' @param programId - The program ID
   ' @param params - Optional query parameters (UserId, etc.)
-  ' @returns Request AA: { method, url }
-  function BuildGetLiveTvProgramRequest(programId as string, params = {} as object) as object
-    return { method: "GET", url: buildURL(Substitute("/LiveTv/Programs/{0}", programId), params) }
+  ' @returns Request AA: { method, url } or invalid if server URL not set
+  function BuildGetLiveTvProgramRequest(programId as string, params = {} as object) as dynamic
+    return m.validatedReq("GET", buildURL(Substitute("/LiveTv/Programs/{0}", programId), params))
   end function
 
   ' Build a request AA to fetch the Live TV schedule, for use with fetchRes() or fetchJson().
   ' Uses POST because the channelIds list can exceed URL length limits.
   ' @param params - Query/body parameters (channelIds, startTime, endTime, UserId, etc.)
-  ' @returns Request AA: { method, url, body, headers }
-  function BuildGetLiveTvScheduleRequest(params as object) as object
+  ' @returns Request AA: { method, url, body, headers } or invalid if server URL not set
+  function BuildGetLiveTvScheduleRequest(params as object) as dynamic
+    url = buildURL("/LiveTv/Programs")
+    if not isValid(url) then return invalid
     return {
       method: "POST",
-      url: buildURL("/LiveTv/Programs"),
+      url: url,
       body: FormatJson(params),
       headers: { "Content-Type": "application/json" }
     }
@@ -714,18 +722,20 @@ class ApiClient
 
   ' Build a request AA to fetch Live TV timer defaults for a program, for use with fetchRes() or fetchJson().
   ' @param programId - The program ID to pre-fill timer defaults
-  ' @returns Request AA: { method, url }
-  function BuildGetLiveTvTimerDefaultsRequest(programId as string) as object
-    return { method: "GET", url: buildURL("/LiveTv/Timers/Defaults", { programId: programId }) }
+  ' @returns Request AA: { method, url } or invalid if server URL not set
+  function BuildGetLiveTvTimerDefaultsRequest(programId as string) as dynamic
+    return m.validatedReq("GET", buildURL("/LiveTv/Timers/Defaults", { programId: programId }))
   end function
 
   ' Build a request AA to create a Live TV recording timer, for use with fetchRes() or fetchJson().
   ' @param defaults - Timer defaults AA from BuildGetLiveTvTimerDefaultsRequest response
-  ' @returns Request AA: { method, url, body, headers }
-  function BuildCreateTimerRequest(defaults as object) as object
+  ' @returns Request AA: { method, url, body, headers } or invalid if server URL not set
+  function BuildCreateTimerRequest(defaults as object) as dynamic
+    url = buildURL("/LiveTv/Timers")
+    if not isValid(url) then return invalid
     return {
       method: "POST",
-      url: buildURL("/LiveTv/Timers"),
+      url: url,
       body: FormatJson(defaults),
       headers: { "Content-Type": "application/json" }
     }
@@ -733,11 +743,13 @@ class ApiClient
 
   ' Build a request AA to create a Live TV series recording timer, for use with fetchRes() or fetchJson().
   ' @param defaults - Timer defaults AA from BuildGetLiveTvTimerDefaultsRequest response
-  ' @returns Request AA: { method, url, body, headers }
-  function BuildCreateSeriesTimerRequest(defaults as object) as object
+  ' @returns Request AA: { method, url, body, headers } or invalid if server URL not set
+  function BuildCreateSeriesTimerRequest(defaults as object) as dynamic
+    url = buildURL("/LiveTv/SeriesTimers")
+    if not isValid(url) then return invalid
     return {
       method: "POST",
-      url: buildURL("/LiveTv/SeriesTimers"),
+      url: url,
       body: FormatJson(defaults),
       headers: { "Content-Type": "application/json" }
     }
@@ -745,16 +757,16 @@ class ApiClient
 
   ' Build a request AA to cancel a Live TV recording timer, for use with SubmitSideEffect().
   ' @param timerId - The timer ID to cancel
-  ' @returns Request AA: { method, url }
-  function BuildCancelTimerRequest(timerId as string) as object
-    return { method: "DELETE", url: buildURL(Substitute("/LiveTv/Timers/{0}", timerId)) }
+  ' @returns Request AA: { method, url } or invalid if server URL not set
+  function BuildCancelTimerRequest(timerId as string) as dynamic
+    return m.validatedReq("DELETE", buildURL(Substitute("/LiveTv/Timers/{0}", timerId)))
   end function
 
   ' Build a request AA to cancel a Live TV series recording timer, for use with SubmitSideEffect().
   ' @param timerId - The series timer ID to cancel
-  ' @returns Request AA: { method, url }
-  function BuildCancelSeriesTimerRequest(timerId as string) as object
-    return { method: "DELETE", url: buildURL(Substitute("/LiveTv/SeriesTimers/{0}", timerId)) }
+  ' @returns Request AA: { method, url } or invalid if server URL not set
+  function BuildCancelSeriesTimerRequest(timerId as string) as dynamic
+    return m.validatedReq("DELETE", buildURL(Substitute("/LiveTv/SeriesTimers/{0}", timerId)))
   end function
 
   ' ═══════════════════════════════════════════════════════════════════════════
@@ -767,6 +779,16 @@ class ApiClient
   ' @returns New params object with defaults merged in
   private function injectDefaults(params as object) as object
     return injectApiParams(params, m.getApiVersion(), m.imageDefaults)
+  end function
+
+  ' Build a request AA with a validated URL from buildURL().
+  ' Returns invalid if URL construction failed (e.g. server URL not set).
+  ' @param method - HTTP method (GET, POST, DELETE, etc.)
+  ' @param url - Result of buildURL() — may be invalid
+  ' @returns Request AA: { method, url } or invalid
+  private function validatedReq(method as string, url as dynamic) as dynamic
+    if not isValid(url) then return invalid
+    return { method: method, url: url }
   end function
 
 end class

--- a/source/api/apiPool.bs
+++ b/source/api/apiPool.bs
@@ -131,7 +131,8 @@ end function
 ' No response is observed. Calls are serialised — do not use for cancellable UI requests.
 '
 ' @param req - request AA: { method, url, headers?, body?, timeout? }
-sub SubmitSideEffect(req as object)
+sub SubmitSideEffect(req as dynamic)
+  if not isValid(req) then return
   sideEffectTask = m.global.sideEffectTask
   if not isValid(sideEffectTask) then return
   sideEffectTask.request = req

--- a/source/api/items.bs
+++ b/source/api/items.bs
@@ -438,7 +438,9 @@ function AudioStream(id as string)
 
       if useTranscodeAudioStream(playbackInfo)
         ' Transcode the audio
-        content.url = buildURL(playbackInfo.mediaSources[0].TranscodingURL)
+        audioUrl = buildURL(playbackInfo.mediaSources[0].TranscodingURL)
+        if not isValid(audioUrl) then return invalid
+        content.url = audioUrl
       else
         ' Direct Stream the audio
         params = {
@@ -447,7 +449,9 @@ function AudioStream(id as string)
           "MediaSourceId": songData.mediaSources[0].id
         }
         content.streamformat = songData.mediaSources[0].container
-        content.url = buildURL(Substitute("Audio/{0}/stream", songData.id), params)
+        audioUrl = buildURL(Substitute("Audio/{0}/stream", songData.id), params)
+        if not isValid(audioUrl) then return invalid
+        content.url = audioUrl
       end if
     else
       return invalid

--- a/source/utils/subtitles.bs
+++ b/source/utils/subtitles.bs
@@ -157,7 +157,10 @@ function sortSubtitles(MediaStreams)
 
       url = ""
       if isValid(stream.DeliveryUrl)
-        url = buildURL(stream.DeliveryUrl)
+        builtUrl = buildURL(stream.DeliveryUrl)
+        if isValid(builtUrl)
+          url = builtUrl as string
+        end if
       end if
 
       stream = {

--- a/tests/source/unit/api/ApiClient.spec.bs
+++ b/tests/source/unit/api/ApiClient.spec.bs
@@ -285,6 +285,350 @@ namespace tests
     end function
 
     '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    @describe("Edge Cases - Missing Server URL (no-userId methods)")
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+    ' These methods have NO userId guard — validatedReq() is their
+    ' only protection against a missing server URL.
+
+    @it("returns invalid from BuildGetArtistByNameRequest when serverUrl is empty")
+    function _()
+      m.global.server.serverUrl = ""
+
+      result = m.apiClient.BuildGetArtistByNameRequest("test-artist")
+
+      m.setupMockServer()
+      m.assertInvalid(result)
+    end function
+
+    @it("returns invalid from BuildGetArtistSimilarRequest when serverUrl is empty")
+    function _()
+      m.global.server.serverUrl = ""
+
+      result = m.apiClient.BuildGetArtistSimilarRequest(m.testItemId)
+
+      m.setupMockServer()
+      m.assertInvalid(result)
+    end function
+
+    @it("returns invalid from BuildGetMediaSegmentsRequest when serverUrl is empty")
+    function _()
+      m.global.server.serverUrl = ""
+
+      result = m.apiClient.BuildGetMediaSegmentsRequest(m.testItemId)
+
+      m.setupMockServer()
+      m.assertInvalid(result)
+    end function
+
+    @it("returns invalid from BuildGetItemLyricsRequest when serverUrl is empty")
+    function _()
+      m.global.server.serverUrl = ""
+
+      result = m.apiClient.BuildGetItemLyricsRequest(m.testItemId)
+
+      m.setupMockServer()
+      m.assertInvalid(result)
+    end function
+
+    @it("returns invalid from BuildDeleteItemRequest when serverUrl is empty")
+    function _()
+      m.global.server.serverUrl = ""
+
+      result = m.apiClient.BuildDeleteItemRequest(m.testItemId)
+
+      m.setupMockServer()
+      m.assertInvalid(result)
+    end function
+
+    @it("returns invalid from BuildGetSessionsRequest when serverUrl is empty")
+    function _()
+      m.global.server.serverUrl = ""
+
+      result = m.apiClient.BuildGetSessionsRequest()
+
+      m.setupMockServer()
+      m.assertInvalid(result)
+    end function
+
+    @it("returns invalid from BuildGetBrandingConfigurationRequest when serverUrl is empty")
+    function _()
+      m.global.server.serverUrl = ""
+
+      result = m.apiClient.BuildGetBrandingConfigurationRequest()
+
+      m.setupMockServer()
+      m.assertInvalid(result)
+    end function
+
+    @it("returns invalid from BuildGetAdditionalPartsRequest when serverUrl is empty")
+    function _()
+      m.global.server.serverUrl = ""
+
+      result = m.apiClient.BuildGetAdditionalPartsRequest(m.testItemId)
+
+      m.setupMockServer()
+      m.assertInvalid(result)
+    end function
+
+    @it("returns invalid from BuildGetSimilarItemsRequest when serverUrl is empty")
+    function _()
+      m.global.server.serverUrl = ""
+
+      result = m.apiClient.BuildGetSimilarItemsRequest(m.testItemId)
+
+      m.setupMockServer()
+      m.assertInvalid(result)
+    end function
+
+    @it("returns invalid from BuildGetFiltersRequest when serverUrl is empty")
+    function _()
+      m.global.server.serverUrl = ""
+
+      result = m.apiClient.BuildGetFiltersRequest()
+
+      m.setupMockServer()
+      m.assertInvalid(result)
+    end function
+
+    @it("returns invalid from BuildHeadItemImageRequest when serverUrl is empty")
+    function _()
+      m.global.server.serverUrl = ""
+
+      result = m.apiClient.BuildHeadItemImageRequest(m.testItemId, "primary")
+
+      m.setupMockServer()
+      m.assertInvalid(result)
+    end function
+
+    @it("returns invalid from BuildGetLiveTVChannelsRequest when serverUrl is empty")
+    function _()
+      m.global.server.serverUrl = ""
+
+      result = m.apiClient.BuildGetLiveTVChannelsRequest()
+
+      m.setupMockServer()
+      m.assertInvalid(result)
+    end function
+
+    @it("returns invalid from BuildGetLiveTVProgramsRequest when serverUrl is empty")
+    function _()
+      m.global.server.serverUrl = ""
+
+      result = m.apiClient.BuildGetLiveTVProgramsRequest()
+
+      m.setupMockServer()
+      m.assertInvalid(result)
+    end function
+
+    @it("returns invalid from BuildGetLiveTvRecommendedProgramsRequest when serverUrl is empty")
+    function _()
+      m.global.server.serverUrl = ""
+
+      result = m.apiClient.BuildGetLiveTvRecommendedProgramsRequest()
+
+      m.setupMockServer()
+      m.assertInvalid(result)
+    end function
+
+    @it("returns invalid from BuildGetStudiosRequest when serverUrl is empty")
+    function _()
+      m.global.server.serverUrl = ""
+
+      result = m.apiClient.BuildGetStudiosRequest()
+
+      m.setupMockServer()
+      m.assertInvalid(result)
+    end function
+
+    @it("returns invalid from BuildGetGenresRequest when serverUrl is empty")
+    function _()
+      m.global.server.serverUrl = ""
+
+      result = m.apiClient.BuildGetGenresRequest()
+
+      m.setupMockServer()
+      m.assertInvalid(result)
+    end function
+
+    @it("returns invalid from BuildGetLiveTvProgramRequest when serverUrl is empty")
+    function _()
+      m.global.server.serverUrl = ""
+
+      result = m.apiClient.BuildGetLiveTvProgramRequest("test-program-id")
+
+      m.setupMockServer()
+      m.assertInvalid(result)
+    end function
+
+    @it("returns invalid from BuildGetLiveTvTimerDefaultsRequest when serverUrl is empty")
+    function _()
+      m.global.server.serverUrl = ""
+
+      result = m.apiClient.BuildGetLiveTvTimerDefaultsRequest("test-program-id")
+
+      m.setupMockServer()
+      m.assertInvalid(result)
+    end function
+
+    @it("returns invalid from BuildCancelTimerRequest when serverUrl is empty")
+    function _()
+      m.global.server.serverUrl = ""
+
+      result = m.apiClient.BuildCancelTimerRequest("test-timer-id")
+
+      m.setupMockServer()
+      m.assertInvalid(result)
+    end function
+
+    @it("returns invalid from BuildCancelSeriesTimerRequest when serverUrl is empty")
+    function _()
+      m.global.server.serverUrl = ""
+
+      result = m.apiClient.BuildCancelSeriesTimerRequest("test-timer-id")
+
+      m.setupMockServer()
+      m.assertInvalid(result)
+    end function
+
+    @it("returns invalid from BuildGetLocalTrailersRequest V2 when serverUrl is empty")
+    function _()
+      m.global.server.serverUrl = ""
+      m.setApiVersion(2)
+
+      result = m.apiClient.BuildGetLocalTrailersRequest(m.testItemId)
+
+      m.setupMockServer()
+      m.assertInvalid(result)
+    end function
+
+    @it("returns invalid from BuildGetSpecialFeaturesRequest V2 when serverUrl is empty")
+    function _()
+      m.global.server.serverUrl = ""
+      m.setApiVersion(2)
+
+      result = m.apiClient.BuildGetSpecialFeaturesRequest(m.testItemId)
+
+      m.setupMockServer()
+      m.assertInvalid(result)
+    end function
+
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    @describe("Edge Cases - Missing Server URL (userId methods)")
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+    ' These methods check userId first, but validatedReq() is still
+    ' needed as a second guard. Tests confirm it isn't accidentally
+    ' removed during refactors (the userId check would mask the gap).
+
+    @it("returns invalid from BuildGetItemRequest when serverUrl is empty")
+    function _()
+      m.global.server.serverUrl = ""
+
+      result = m.apiClient.BuildGetItemRequest(m.testItemId)
+
+      m.setupMockServer()
+      m.assertInvalid(result)
+    end function
+
+    @it("returns invalid from BuildGetViewsRequest when serverUrl is empty")
+    function _()
+      m.global.server.serverUrl = ""
+
+      result = m.apiClient.BuildGetViewsRequest()
+
+      m.setupMockServer()
+      m.assertInvalid(result)
+    end function
+
+    @it("returns invalid from BuildGetNextUpRequest when serverUrl is empty")
+    function _()
+      m.global.server.serverUrl = ""
+
+      result = m.apiClient.BuildGetNextUpRequest({})
+
+      m.setupMockServer()
+      m.assertInvalid(result)
+    end function
+
+    @it("returns invalid from BuildMarkFavoriteRequest when serverUrl is empty")
+    function _()
+      m.global.server.serverUrl = ""
+
+      result = m.apiClient.BuildMarkFavoriteRequest(m.testItemId)
+
+      m.setupMockServer()
+      m.assertInvalid(result)
+    end function
+
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    @describe("Edge Cases - Missing Server URL (POST methods)")
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+    ' POST methods that do manual buildURL() + isValid() checks
+    ' instead of using validatedReq() directly.
+
+    @it("returns invalid from BuildPostPlaybackInfoRequest when serverUrl is empty")
+    function _()
+      m.global.server.serverUrl = ""
+
+      result = m.apiClient.BuildPostPlaybackInfoRequest(m.testItemId, {})
+
+      m.setupMockServer()
+      m.assertInvalid(result)
+    end function
+
+    @it("returns invalid from BuildPlaystateRequest when serverUrl is empty")
+    function _()
+      m.global.server.serverUrl = ""
+
+      result = m.apiClient.BuildPlaystateRequest("start", { ItemId: m.testItemId })
+
+      m.setupMockServer()
+      m.assertInvalid(result)
+    end function
+
+    @it("returns invalid from BuildPostSessionCapabilitiesRequest when serverUrl is empty")
+    function _()
+      m.global.server.serverUrl = ""
+
+      result = m.apiClient.BuildPostSessionCapabilitiesRequest({})
+
+      m.setupMockServer()
+      m.assertInvalid(result)
+    end function
+
+    @it("returns invalid from BuildGetLiveTvScheduleRequest when serverUrl is empty")
+    function _()
+      m.global.server.serverUrl = ""
+
+      result = m.apiClient.BuildGetLiveTvScheduleRequest({})
+
+      m.setupMockServer()
+      m.assertInvalid(result)
+    end function
+
+    @it("returns invalid from BuildCreateTimerRequest when serverUrl is empty")
+    function _()
+      m.global.server.serverUrl = ""
+
+      result = m.apiClient.BuildCreateTimerRequest({})
+
+      m.setupMockServer()
+      m.assertInvalid(result)
+    end function
+
+    @it("returns invalid from BuildCreateSeriesTimerRequest when serverUrl is empty")
+    function _()
+      m.global.server.serverUrl = ""
+
+      result = m.apiClient.BuildCreateSeriesTimerRequest({})
+
+      m.setupMockServer()
+      m.assertInvalid(result)
+    end function
+
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
     @describe("V1/V2 Routing - URL Path Verification")
     '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 


### PR DESCRIPTION
Fixes a production crash on v2.11.1 where an invalid (unset) server URL reaches the HTTP library and causes a type mismatch runtime error.

```
Type Mismatch. Unable to cast "Invalid" to "String". (runtime error &h18) in pkg:/source/roku_modules/rr/Requests.brs(28)
Backtrace:
#2  Function rr_requests_request(method As Dynamic, url As String, args As Object) As Dynami$1 file/line: pkg:/source/roku_modules/rr/Requests.brs(28)
#1  Function executerequest(req As Object) As Objec$1 file/line: pkg:/components/api/ApiTask.brs(67)
#0  Function runapiloop() As Voi$1 file/line: pkg:/components/api/ApiTask.brs(29)
Local Variables:
method           String (2.1 was roString) (VT_STR_CONST) val:"GET"
url              Invali$1 args             roAssociativeArray refcnt=2 count:3
```

The root cause is `buildURL()` returning `invalid` when the server URL is not set (e.g. first launch, cleared registry), and callers embedding that `invalid` directly into request AAs without checking. The request AA itself passes validation (`isValid(req)` is true), but `req.url` is `invalid`, which crashes when passed to the HTTP library's `url as String` parameter.

## Changes

- Add URL validation in `executeRequest()` and `executeSideEffect()` as a safety net — returns an error response instead of crashing when `req.url` is invalid or empty
- Add `validatedReq()` private helper to ApiClient and update all `Build*Request()` methods to return `invalid` instead of `{ url: invalid }` when `buildURL()` fails — callers already handle `invalid` returns via `fetchRes()`'s existing guard
- Update return types from `as object` to `as dynamic` on methods that can now return `invalid`
- Add `buildURL()` return validation in all remaining call sites outside ApiClient: `LoadVideoContentTask` (video transcoding/streaming URLs), `items.bs` (audio streaming URLs), `FontDownloadTask` (encoding config and font list URLs), `subtitles.bs` (subtitle delivery URLs)