### PR TITLE
fix: prevent stale field re-fires on scene restore (quickPlayNode/selectedItem)

### DIFF
--- a/components/ItemDetails.bs
+++ b/components/ItemDetails.bs
@@ -3229,6 +3229,19 @@ end function
 ' Called automatically by SceneManager.popScene() / clearScenes()
 sub destroy()
   m.log.verbose("destroy")
+
+  ' Tear down ExtrasRowList FIRST — stops in-flight tasks (including any
+  ' LoadChannelProgramsTask started by onProgramsExpired) and unobserves all
+  ' fields before we destroy the texture manager or null out references.
+  m.extrasGrid.callFunc("destroy")
+
+  ' Unobserve m.port observers set by showScenes.bs CreateItemDetailsGroup().
+  ' These persist until the node is garbage collected, so explicit cleanup
+  ' prevents stale events from reaching main.bs's event loop after popScene.
+  m.top.unobserveField("quickPlayNode")
+  m.extrasGrid.unobserveField("selectedItem")
+  m.buttonGrp.unobserveField("buttonSelected")
+
   destroyTextureManager(m.extrasGrid.content)
 
   ' Safety net: stop the loading spinner in case the component is destroyed

--- a/components/ItemDetails.bs
+++ b/components/ItemDetails.bs
@@ -3093,6 +3093,7 @@ sub onFirstEpisodeLoaded()
 
   if isValid(content) and content.count() > 0
     m.top.quickPlayNode = content[0]
+    m.top.quickPlayNode = invalid
   else
     m.log.warn("Series Play: could not load first episode for series", m.top.itemContent.id)
     m.global.sceneManager.callFunc("standardDialog", translate(translationKeys.ErrorPlaybackError), { data: ["<p>" + translate(translationKeys.ErrorCouldNotLoadTheFirstEpisode) + "</p>"] })
@@ -3127,6 +3128,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
         return true
       else if focusedButton.id = "resumeButton" and isValid(m.top.nextUpEpisode) and isValidAndNotEmpty(m.top.nextUpEpisode.id)
         m.top.quickPlayNode = m.top.nextUpEpisode
+        m.top.quickPlayNode = invalid
         return true
       end if
     end if
@@ -3215,6 +3217,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
   else if key = "play" and m.extrasGrid.hasFocus()
     if isValid(m.extrasGrid.focusedItem)
       m.top.quickPlayNode = m.extrasGrid.focusedItem
+      m.top.quickPlayNode = invalid
       return true
     end if
   end if

--- a/components/ItemGrid/BaseGridView.bs
+++ b/components/ItemGrid/BaseGridView.bs
@@ -1013,6 +1013,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
       if isValid(m.channelFocused)
         m.log.debug("quickplay channel", "id", m.channelFocused.id, "type", m.channelFocused.type)
         m.top.quickPlayNode = m.channelFocused
+        m.top.quickPlayNode = invalid
         return true
       end if
     end if
@@ -1021,6 +1022,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
 
     if isValid(itemToPlay)
       m.top.quickPlayNode = itemToPlay
+      m.top.quickPlayNode = invalid
       return true
     end if
   else if key = "left"

--- a/components/extras/ExtrasRowList.bs
+++ b/components/extras/ExtrasRowList.bs
@@ -1126,6 +1126,67 @@ sub updatePanelPosition(rowIndex as integer)
   end if
 end sub
 
+' destroy: Full teardown releasing all resources before component removal.
+' Called by ItemDetails.destroy() before nulling the extrasGrid reference.
+sub destroy()
+  ' Stop all in-flight tasks and unobserve their content fields
+  cancelInFlightChain()
+
+  ' Stop and release the program progress timer (inherited from JRRowList)
+  stopProgramProgressTicking(true)
+
+  ' Unobserve m.top fields set in init()
+  m.top.unobserveField("rowItemSelected")
+  m.top.unobserveField("rowItemFocused")
+  m.top.unobserveField("programsExpired")
+
+  ' Release task references
+  m.LoadSeasonsTask = invalid
+  m.LoadSeasonAllEpisodesTask = invalid
+  m.LoadSeasonEpisodesTask = invalid
+  m.LoadAdditionalPartsTask = invalid
+  m.LoadPeopleTask = invalid
+  m.LikeThisTask = invalid
+  m.SpecialFeaturesTask = invalid
+  m.LoadMoviesTask = invalid
+  m.LoadShowsTask = invalid
+  m.LoadSeriesTask = invalid
+  m.LoadBoxSetItemsTask = invalid
+  m.LoadArtistAlbumsTask = invalid
+  m.LoadArtistAppearsOnTask = invalid
+  m.LoadArtistSongsTask = invalid
+  m.LoadArtistSimilarTask = invalid
+  m.LoadAlbumSongsTask = invalid
+  m.LoadPlaylistItemsTask = invalid
+  m.LoadPhotoAlbumItemsTask = invalid
+  m.LoadChannelProgramsTask = invalid
+
+  ' Clear row references
+  m.rowChapters = invalid
+  m.rowAdditionalParts = invalid
+  m.rowSeasons = invalid
+  m.rowEpisodes = invalid
+  m.rowSeasonEpisodes = invalid
+  m.rowCast = invalid
+  m.rowLikeThis = invalid
+  m.rowSpecialFeatures = invalid
+  m.rowBoxSetItems = invalid
+  m.rowMovies = invalid
+  m.rowTvShows = invalid
+  m.rowSeries = invalid
+  m.rowArtistAlbums = invalid
+  m.rowArtistAppearsOn = invalid
+  m.rowArtistSongs = invalid
+  m.rowAlbumSongs = invalid
+  m.rowAlbumArtistAlbums = invalid
+  m.rowPlaylistItems = invalid
+  m.rowPhotoAlbumItems = invalid
+  m.rowChannelPrograms = invalid
+
+  ' Reset flags
+  m.isRefetchingChannelPrograms = false
+end sub
+
 ' onKeyEvent: Anticipate the next row on UP/DOWN so the panel translation animation starts
 ' in sync with the RowList floatingFocus animation rather than after it completes.
 ' Returns false so the RowList handles the actual navigation.

--- a/components/extras/ExtrasRowList.bs
+++ b/components/extras/ExtrasRowList.bs
@@ -1050,6 +1050,9 @@ end sub
 
 sub onRowItemSelected()
   m.top.selectedItem = m.top.content.getChild(m.top.rowItemSelected[0]).getChild(m.top.rowItemSelected[1])
+  ' Clear immediately — prevents stale value from re-firing the m.port
+  ' observer when the parent ItemDetails screen is restored after popScene.
+  m.top.selectedItem = invalid
 end sub
 
 sub onRowItemFocused()

--- a/components/extras/ExtrasRowList.xml
+++ b/components/extras/ExtrasRowList.xml
@@ -8,6 +8,7 @@
     <field id="selectedItem" type="node" alwaysNotify="true" />
     <function name="loadParts" />
     <function name="loadPersonVideos" />
+    <function name="destroy" />
     <field id="personHasMedia" type="bool" value="false" alwaysNotify="true" />
     <field id="playlistContentKind" type="string" value="unknown" alwaysNotify="true" />
     <!-- Target Y for animating the RowList's translation within extrasGrp.

--- a/components/home/FavoritesRows.bs
+++ b/components/home/FavoritesRows.bs
@@ -336,6 +336,9 @@ function onKeyEvent(key as string, press as boolean) as boolean
       itemToPlay = getItemAtIndices(m.top.rowItemFocused)
       if isValid(itemToPlay) and itemToPlay.type <> "Loading"
         m.top.quickPlayNode = itemToPlay
+        ' Clear immediately — same pattern as selectedItem. Prevents stale
+        ' value from re-firing when the screen is restored after playback.
+        m.top.quickPlayNode = invalid
       end if
       return true
     else if key = "replay"

--- a/components/home/Home.bs
+++ b/components/home/Home.bs
@@ -295,7 +295,9 @@ sub onRowItemSelected(msg)
   m.top.selectedItem = msg.getData()
 end sub
 
-' Proxy quickPlayNode from whichever row list fires it
+' Proxy quickPlayNode from whichever row list fires it.
+' Must pass through invalid clears so Home.quickPlayNode doesn't retain
+' a stale value that re-fires the m.port observer on screen restoration.
 sub onQuickPlayNode(msg)
   m.top.quickPlayNode = msg.getData()
 end sub

--- a/components/home/HomeRows.bs
+++ b/components/home/HomeRows.bs
@@ -191,16 +191,19 @@ sub startParallelLoads()
     if section.type = "resume"
       if m.isLoadingResume then continue for
       m.isLoadingResume = true
+      m.LoadContinueWatchingTask.unobserveField("content")
       m.LoadContinueWatchingTask.observeField("content", "updateContinueWatchingItems")
       m.LoadContinueWatchingTask.control = "RUN"
     else if section.type = "nextup"
       if m.isLoadingNextUp then continue for
       m.isLoadingNextUp = true
+      m.LoadNextUpTask.unobserveField("content")
       m.LoadNextUpTask.observeField("content", "updateNextUpItems")
       m.LoadNextUpTask.control = "RUN"
     else if section.type = "livetv"
       if m.isLoadingOnNow then continue for
       m.isLoadingOnNow = true
+      m.LoadOnNowTask.unobserveField("content")
       m.LoadOnNowTask.observeField("content", "updateOnNowItems")
       m.LoadOnNowTask.control = "RUN"
     end if
@@ -806,6 +809,7 @@ sub destroy()
   ' Unobserve m.top fields
   m.top.unobserveField("rowItemSelected")
   m.top.unobserveField("rowItemFocused")
+  m.top.unobserveField("programsExpired")
 
   ' Stop and release all persistent task nodes
   m.LoadLibrariesTask.unobserveField("content")

--- a/components/home/HomeRows.bs
+++ b/components/home/HomeRows.bs
@@ -781,6 +781,9 @@ function onKeyEvent(key as string, press as boolean) as boolean
       itemToPlay = getItemAtIndices(m.top.rowItemFocused)
       if isValid(itemToPlay) and itemToPlay.type <> "Loading"
         m.top.quickPlayNode = itemToPlay
+        ' Clear immediately — same pattern as selectedItem. Prevents stale
+        ' value from re-firing when the screen is restored after playback.
+        m.top.quickPlayNode = invalid
       end if
       return true
     else if key = "replay"

--- a/components/search/SearchResults.bs
+++ b/components/search/SearchResults.bs
@@ -167,6 +167,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
         selectedItem = selectedContent.getChild(m.searchSelect.rowItemFocused[1])
         if isValid(selectedItem)
           m.top.quickPlayNode = selectedItem
+          m.top.quickPlayNode = invalid
           return true
         end if
       end if

--- a/components/ui/rowlist/JRRowList.bs
+++ b/components/ui/rowlist/JRRowList.bs
@@ -115,6 +115,7 @@ sub startProgramProgressTicking()
   ' trigger unnecessary refetches before the screen's own refresh has landed.
   m.suppressNextExpiry = true
   onProgramProgressTick()
+  m.suppressNextExpiry = false
 end sub
 
 sub stopProgramProgressTicking(releaseTimer = false as boolean)

--- a/components/ui/rowlist/JRRowList.bs
+++ b/components/ui/rowlist/JRRowList.bs
@@ -35,6 +35,7 @@ sub init()
   m.programProgressTimer = invalid
   m.observedContentRoot = invalid
   m.isProgramProgressTicking = false
+  m.suppressNextExpiry = false
 
   m.top.observeField("content", "onProgramProgressContentChanged")
 end sub
@@ -108,7 +109,11 @@ sub startProgramProgressTicking()
   m.isProgramProgressTicking = true
 
   ' Immediate refresh so returning from Settings/another screen does not
-  ' leave stale percentages on screen for up to 60 seconds.
+  ' leave stale percentages on screen for up to 60 seconds. Suppress expiry
+  ' detection on this first tick — the data is stale (from before the user
+  ' navigated away) and almost always contains expired programs, which would
+  ' trigger unnecessary refetches before the screen's own refresh has landed.
+  m.suppressNextExpiry = true
   onProgramProgressTick()
 end sub
 
@@ -190,7 +195,11 @@ sub onProgramProgressTick()
   end for
 
   if hasExpiredProgram
-    m.top.programsExpired = true
+    if m.suppressNextExpiry
+      m.suppressNextExpiry = false
+    else
+      m.top.programsExpired = true
+    end if
   end if
 end sub
 

--- a/source/main.bs
+++ b/source/main.bs
@@ -96,11 +96,10 @@ sub Main (args as dynamic) as void
         handleFontDownloadCompletion(fontDownloadTask)
       end if
     else if isNodeEvent(msg, "quickPlayNode")
-      reportingNode = msg.getRoSGNode()
-      itemNode = invalid
-      if isValid(reportingNode) and isValid(reportingNode.quickPlayNode)
-        itemNode = reportingNode.quickPlayNode
-      end if
+      ' Read from msg.getData() — the value at event-queue time — not from
+      ' the current field value which may already be cleared to invalid by
+      ' the set-then-clear pattern that prevents stale re-fires.
+      itemNode = msg.getData()
       if isValid(itemNode) and isValid(itemNode.id) and itemNode.id <> ""
         itemType = invalid
         if isValid(itemNode.type) and itemNode.type <> ""


### PR DESCRIPTION
## Summary

Fixes two regressions introduced by #486 where Roku's SceneGraph re-notifies `m.port` observers on interface fields that retain non-default values during scene visibility transitions. The immediate `onProgramProgressTick()` added by #486 triggers enough render-thread activity during `OnScreenShown` to consistently expose this platform behavior, causing quickplay auto-replay and back-navigation loops.

## Changes

- Apply set-then-clear pattern to every `quickPlayNode` setter across the codebase (HomeRows, FavoritesRows, ItemDetails, BaseGridView, SearchResults) — set the value then immediately clear to invalid, matching the existing `selectedItem` pattern in HomeRows
- Apply set-then-clear to `ExtrasRowList.onRowItemSelected` for `selectedItem` (was missing, unlike HomeRows which already had it)
- Switch `main.bs` quickPlayNode handler to read `msg.getData()` (event-queue-time value) instead of `reportingNode.quickPlayNode` (current field value, already cleared)
- Update `Home.onQuickPlayNode` proxy to pass through invalid clears so `Home.quickPlayNode` doesn't retain stale values
- Add `ExtrasRowList.destroy()` method with full teardown (cancelInFlightChain, stop timer, unobserve fields, release references)
- Update `ItemDetails.destroy()` to call `extrasGrid.destroy()` and unobserve m.port observers (quickPlayNode, selectedItem, buttonSelected) set by showScenes.bs
- Suppress `programsExpired` on the first tick after activation to avoid unnecessary refetches on stale data during screen return
- Add defensive `unobserveField("content")` before `observeField` in `HomeRows.startParallelLoads()`
- Add `unobserveField("programsExpired")` to `HomeRows.destroy()`

## Test plan

- [ ] Quickplay from On Now row → back → no auto-replay, no spinner
- [ ] Select TvChannel → select Program from extras → back → clean return to TvChannel, no reload loop
- [ ] Quickplay from Favorites, Search, ItemDetails extras, BaseGridView → back → no auto-replay
- [ ] Wait 60s on Home → progress bars advance on Program cells
- [ ] Wait for a program to end → On Now row refreshes with new data
- [ ] Continue Watching / Next Up rows unaffected
- [ ] Tab switch Home → Favorites → Home → quickplay works normally