### PR TITLE
fix(chapters): align synthetic-chapter threshold with displayed runtime

### DIFF
--- a/source/utils/chapterItems.bs
+++ b/source/utils/chapterItems.bs
@@ -11,10 +11,14 @@ function buildChapterItems(data as object) as object
   chapters = data.chapters
   runTimeTicks = data.runTimeTicks
 
-  ' If no real chapters, generate synthetic ones for videos >= 10 minutes
+  ' If no real chapters, generate synthetic ones for videos that display as ≥ 10 minutes.
+  ' ItemDetails.getRuntime() uses round() to the nearest minute, so a 9:30 video shows as
+  ' "10 mins" on screen. Match that rounding here so the Chapters row presence is consistent
+  ' with the displayed runtime — otherwise the user sees "10 mins" but no row, which feels
+  ' broken. Threshold: 9:30 = 5.7B ticks (equivalent to round(minutes) >= 10).
   if not isValidAndNotEmpty(chapters)
-    TEN_MINUTES_TICKS = 6000000000&
-    if not isValid(runTimeTicks) or runTimeTicks < TEN_MINUTES_TICKS then return []
+    MIN_CHAPTER_RUNTIME_TICKS = 5700000000&
+    if not isValid(runTimeTicks) or runTimeTicks < MIN_CHAPTER_RUNTIME_TICKS then return []
 
     chapters = generateSyntheticChapters(runTimeTicks)
   end if


### PR DESCRIPTION
## Overview

`ItemDetails.getRuntime()` rounds runtime to the nearest minute, so a 9:30 video displays as "10 mins" on screen. `buildChapterItems()` used a strict floor at 10:00 (`6_000_000_000` ticks), so a 9:56 episode would display "10 mins" but get no Chapters row — making it feel like a bug. This aligns the synthetic-chapter threshold with the rounded runtime the user actually sees.

## Changes

- Lower `MIN_CHAPTER_RUNTIME_TICKS` to `5_700_000_000` (9:30), the tick-equivalent of `round(minutes) >= 10`, so videos that display as 10+ mins consistently get the Chapters row.
- Rename the local constant from `TEN_MINUTES_TICKS` to `MIN_CHAPTER_RUNTIME_TICKS` so the name reflects its actual semantics.
- Update the inline comment explaining why the threshold is not a round tick boundary.

## Test plan

- [ ] Open ItemDetails for a video with runtime between 9:30 and 9:59 (displays "10 mins"): Chapters row appears.
- [ ] Open ItemDetails for a video with runtime < 9:30 (displays "9 mins" or less): Chapters row absent.
- [ ] Open ItemDetails for any video >= 10:00: Chapters row appears (regression check).