### PR TITLE
fix(itemdetails): stable date-added label position on first render

### DIFF
--- a/components/ItemDetails.bs
+++ b/components/ItemDetails.bs
@@ -23,6 +23,11 @@ const LOGO_MAX_DISPLAY_WIDTH = 500
 ' extending above the metadata rows. Person photos are exempt because their info rows
 ' are short and don't reach the right edge where the photo sits.
 const LOGO_MAX_DISPLAY_HEIGHT = 336
+' First-frame estimate for the button row's total rendered height. Used by anchorDateLabel()
+' before boundingRect() has settled (it reports height=0 during initial render). Observed to
+' land around 130 px for the typical 2-line-label icon button. A later renderTracking callback
+' replaces this with the real measured height once layout completes.
+const ESTIMATED_BUTTON_ROW_HEIGHT_PX = 130
 
 sub init()
   m.log = new log.Logger("ItemDetails")
@@ -2221,19 +2226,13 @@ end sub
 ' anchorDateLabel: Derive the date label's Y position from the button group's position.
 ' Returns dateLabelY so callers (e.g. logo positioning) can use it without duplicating the math.
 ' Safe to call multiple times — idempotent, and safe to call BEFORE the button group has
-' finished laying out: falls back to the group's fixed translation + a safe button-height
-' estimate so the label never lands off-screen. A later renderTracking callback will refine
-' the position once the real rendered height is known.
-' @return {float} dateLabelY — the Y coordinate used for the date label
-function anchorDateLabel() as float
-  ' Default: use the button group's XML-declared translation plus a conservative estimate
-  ' of the button row's height (~130 px for icon + label). This places the label correctly
-  ' even on first call, before boundingRect has settled.
-  buttonY = 800
-  buttonHeight = 130
-  if isValid(m.buttonGrp) and m.buttonGrp.translation.count() > 1
-    buttonY = m.buttonGrp.translation[1]
-  end if
+' finished laying out: falls back to the group's fixed translation + ESTIMATED_BUTTON_ROW_HEIGHT_PX
+' so the label never lands off-screen. A later renderTracking callback refines the position
+' once the real rendered height is known.
+' @return {integer} dateLabelY — the Y coordinate used for the date label
+function anchorDateLabel() as integer
+  buttonY = m.buttonGrp.translation[1]
+  buttonHeight = ESTIMATED_BUTTON_ROW_HEIGHT_PX
 
   ' Refine with the measured height once layout has settled. Ignore the degenerate 0-size
   ' bounding rect reported during the initial render — that's what was pushing the label

--- a/components/ItemDetails.bs
+++ b/components/ItemDetails.bs
@@ -2208,22 +2208,42 @@ sub setDateAdded(item as object)
   dateAdded.toLocalTime()
   m.dateCreatedLabel.text = translate(translationKeys.LabelAdded) + " " + dateAdded.AsDateString("short-month-no-weekday") + " " + formatTime(dateAdded)
 
-  ' Set X position only — Y is deferred to anchorDateLabel() which runs after the
-  ' button group layout settles (via renderTracking observer).
-  ' Preserve the existing Y so that on refresh the label keeps its correct position
-  ' from the previous positioning cycle rather than resetting to 0 (top of screen).
+  ' Set X here; Y is computed by anchorDateLabel() which handles both the initial
+  ' placement (using the button group's XML translation + a safe height estimate) and
+  ' later refinements when the button group's actual rendered height is known. Calling
+  ' it here guarantees the label is correctly positioned on the very first render —
+  ' no flash at the top of the screen.
   m.dateCreatedLabel.translation = [1920 - 96 - 450, m.dateCreatedLabel.translation[1]]
   m.dateCreatedLabel.visible = true
+  anchorDateLabel()
 end sub
 
-' anchorDateLabel: Derive the date label's Y position from the button group's rendered rect.
+' anchorDateLabel: Derive the date label's Y position from the button group's position.
 ' Returns dateLabelY so callers (e.g. logo positioning) can use it without duplicating the math.
-' Safe to call multiple times — idempotent.
+' Safe to call multiple times — idempotent, and safe to call BEFORE the button group has
+' finished laying out: falls back to the group's fixed translation + a safe button-height
+' estimate so the label never lands off-screen. A later renderTracking callback will refine
+' the position once the real rendered height is known.
 ' @return {float} dateLabelY — the Y coordinate used for the date label
 function anchorDateLabel() as float
+  ' Default: use the button group's XML-declared translation plus a conservative estimate
+  ' of the button row's height (~130 px for icon + label). This places the label correctly
+  ' even on first call, before boundingRect has settled.
+  buttonY = 800
+  buttonHeight = 130
+  if isValid(m.buttonGrp) and m.buttonGrp.translation.count() > 1
+    buttonY = m.buttonGrp.translation[1]
+  end if
+
+  ' Refine with the measured height once layout has settled. Ignore the degenerate 0-size
+  ' bounding rect reported during the initial render — that's what was pushing the label
+  ' to y=-30 on the Series detail screen.
   buttonRect = m.buttonGrp.boundingRect()
-  buttonBottom = buttonRect.y + buttonRect.height
-  dateLabelY = buttonBottom - 30
+  if buttonRect.height > 0
+    buttonHeight = buttonRect.height
+  end if
+
+  dateLabelY = buttonY + buttonHeight - 30
 
   if isValid(m.dateCreatedLabel) and m.dateCreatedLabel.visible
     m.dateCreatedLabel.translation = [m.dateCreatedLabel.translation[0], dateLabelY]


### PR DESCRIPTION
## Overview

The "Added …" label on ItemDetails was landing at `y=-30` (barely visible at the top of the screen) on the Series detail screen, and on Episode details it flashed at the top before jumping under the logo once layout settled.

`anchorDateLabel()` relied on `m.buttonGrp.boundingRect()`, which returns a 0-size rect before the button group has finished laying out. That produced `dateLabelY = 0 + 0 - 30 = -30`. For Series the only `renderTracking` event caught this bad state and never fired again; for Episodes a second event eventually arrived and moved the label.

## Changes

- `anchorDateLabel()` now anchors off the button group's XML-declared translation plus a safe 130 px button-height estimate, so the label lands on-screen even on first call before layout settles.
- Refine with `boundingRect()` only when its height is actually `> 0`, so the zero-size early-render rect can no longer push the label off-screen.
- `setDateAdded()` calls `anchorDateLabel()` inline instead of waiting for the `renderTracking` observer, guaranteeing correct Y position on the very first render with no visible jump regardless of item type or logo load timing.
- Update surrounding comments to match the new invariants.

## Test plan

- [ ] Open a Series detail screen cold: "Added …" label lands under the button group, not at the top of the screen.
- [ ] Open an Episode detail screen cold: no flash at the top before landing in the correct position.
- [ ] Open a Movie detail screen: label position unchanged from prior behavior.
- [ ] Refresh ItemDetails (source switch, metadata update): label stays put, no regression.