### PR TITLE
ci: harden device-unit-tests with --ignore-scripts + explicit ropm

### DIFF
--- a/.github/workflows/device-unit-tests.yml
+++ b/.github/workflows/device-unit-tests.yml
@@ -89,8 +89,16 @@ jobs:
           node-version: "lts/*"
           cache: "npm"
 
-      - name: Install dependencies
-        run: npm ci
+      # Security: --ignore-scripts blocks transitive deps' install/postinstall hooks,
+      # which is the highest-bandwidth pull_request_target exfiltration path
+      # (a malicious PR adds a dep whose postinstall reads runner env vars).
+      # We then run our OWN postinstall by name — `ropm` is in this repo, vetted.
+      # If a future trusted dep needs install scripts, add it to an explicit
+      # `npm rebuild <pkg>` line below — never re-enable scripts globally.
+      - name: Install dependencies (security-hardened)
+        run: |
+          npm ci --ignore-scripts
+          npm run ropm
 
       - name: Run unit tests on Roku
         if: github.event.inputs.test_type == 'unit'


### PR DESCRIPTION
## Summary

Hardens the `device-unit-tests` workflow against the highest-bandwidth `pull_request_target` exfiltration vector: a malicious PR adding a dependency whose `postinstall` reads the runner's env vars (e.g., the GitHub App private key).

**Change:** `npm ci` → `npm ci --ignore-scripts && npm run ropm`

- `--ignore-scripts` blocks **transitive** deps' install/postinstall hooks. Out of 636 packages in our lockfile, only 1 (`fsevents`) has an install script, and it's a no-op on Linux — so the practical-impact loss is zero.
- We then re-invoke our **own** postinstall (`npm run ropm`) by name. ropm lives in this repo, is vetted in code review, and copies BrightScript modules from `node_modules/` into `components/roku_modules/`.

## Why this matters

`pull_request_target` runs in the base-repo context with full secrets. Even with environment approval gating the run, once approved the workflow executes attacker-controlled code from the PR — including any transitive dep's install scripts. Reviewing the PR's diff doesn't catch malice nested in a new dependency's `package.json`.

By disabling transitive install scripts and only allowlisting our own (named) postinstall, the runner can no longer be hijacked by a PR-added dep without the maintainer also explicitly adding it to a `npm rebuild <pkg>` allowlist.

## Test plan

Validated locally on `origin/main` (commit `7be642c3`):

- [x] `npm ci --ignore-scripts` succeeds (4s, 635 packages)
- [x] `npm run ropm` succeeds (1.6s, copies log/bslib/rr modules)
- [x] `npm run build` succeeds (8s)
- [x] `npm run build:prod` succeeds (8s)
- [x] `npm run build:tests` succeeds (15s) — required for the runner workflow

End-to-end test: after merging, the next PR run will exercise the new install path on the actual Roku runner.

## Follow-ups (not in this PR)

- Move the GitHub App private key out of the runner container's env (separate work — biggest remaining mitigation).
- Apply the same `--ignore-scripts` pattern to `automations.yml` (also uses `pull_request_target`, lower risk since it doesn't run on self-hosted).