### PR TITLE
ci: restrict GITHUB_TOKEN to contents:read + drop checkout token persistence

### DIFF
--- a/.github/workflows/device-unit-tests.yml
+++ b/.github/workflows/device-unit-tests.yml
@@ -47,6 +47,14 @@ on:
           - all
           - complete
 
+# Restrict the default GITHUB_TOKEN to read-only contents access. This workflow
+# only checks out code, installs deps, and runs tests on the Roku — it never
+# pushes, comments, or otherwise mutates the repo. Without this, a malicious
+# pull_request_target PR could harvest the broadly-scoped default token from
+# .git/config (left there by actions/checkout) and use it to push to main.
+permissions:
+  contents: read
+
 jobs:
   check-skip:
     runs-on: ubuntu-latest
@@ -79,10 +87,15 @@ jobs:
     # rules gate at the job level regardless of who opened the PR.
     environment: roku-device
     steps:
-      # Explicitly checkout PR code - pull_request_target defaults to base branch
+      # Explicitly checkout PR code - pull_request_target defaults to base branch.
+      # persist-credentials: false prevents actions/checkout from writing the
+      # GITHUB_TOKEN into .git/config; combined with the workflow-level
+      # `permissions: contents: read` above, this means PR code can't harvest
+      # a write-capable token from the workspace.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:


### PR DESCRIPTION
## Summary

Closes the residual `.git/config` token-harvest path on `pull_request_target` runs that we identified after #508 landed.

**Two changes, both well-documented stable Actions features:**

1. **Workflow-level `permissions: contents: read`** — restricts the default `GITHUB_TOKEN` to read-only repo content access for every job in this workflow.
2. **`persist-credentials: false` on `actions/checkout`** — prevents the token from being written into `.git/config` as a basic-auth header.

## Why both

Either alone closes most of the gap; together they're belt-and-suspenders:

- `permissions: contents: read` means even if a malicious PR did harvest the token, it can only *read* the repo (which they could already do as an open-source contributor anyway).
- `persist-credentials: false` means the token isn't sitting on the workspace filesystem at all after checkout, so harvest attempts find nothing.

## What this does NOT change

- Roku creds (`ROKU_IP`, `ROKU_PASSWORD`) are still passed to test steps as expected
- Environment approval gating (`environment: roku-device`) is unaffected
- Test execution on the Roku is unaffected
- `npm ci --ignore-scripts` + `npm run ropm` install pattern is unaffected
- `actions/upload-artifact` uses `ACTIONS_RUNTIME_TOKEN`, not `GITHUB_TOKEN`, so artifact uploads still work

## Test plan

I walked every step in this workflow and confirmed none need GITHUB_TOKEN write or post-checkout git operations:

| Step | Needs token write? | Needs post-checkout git? |
|---|---|---|
| `actions/checkout` | reads only | initial clone uses token, then done |
| `actions/setup-node` | no | no |
| `npm ci --ignore-scripts` | no (npm registry) | no |
| `npm run ropm` | no (filesystem-only) | no |
| `npm run test:*` | no (talks to Roku) | no |
| `actions/upload-artifact` | uses `ACTIONS_RUNTIME_TOKEN` | no |

**Recommended pre-merge validation:** trigger this workflow on this branch via `gh workflow run device-unit-tests.yml --ref harden/restrict-token-permissions` (or via the UI), approve the env gate, and confirm tests still pass on the Roku before merging. Failure mode if I missed something is loud (`Resource not accessible by integration` or `fatal: could not read Username`), not silent — easy to revert.

## Future-proofing notes

- If a future step needs to write to the repo (e.g., comment on PRs with test results), add a per-step `permissions:` override or use a different token. Don't broaden the workflow-level permissions.
- If a future dep adds a private GitHub git URL, you'll need to either re-enable `persist-credentials: true` for that workflow or use a deploy key.

## Refs

- [`permissions` syntax](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#permissions)
- [`actions/checkout` `persist-credentials`](https://github.com/actions/checkout#usage)
- [Security hardening for GitHub Actions](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions)